### PR TITLE
Fix dashboard exit issues and q key binding

### DIFF
--- a/lib/dashboard.sh
+++ b/lib/dashboard.sh
@@ -52,15 +52,19 @@ collect_session_panes() {
             continue
         fi
         
-        # Get the first pane from the session
-        pane_id="$(tmux list-panes -t "$session:0" -F '#{pane_id}' | head -1 2>/dev/null)" || continue
+        # Get the first pane from the session with its window ID
+        pane_info="$(tmux list-panes -t "$session" -F '#{pane_id} #{window_id}' | head -1 2>/dev/null)" || continue
         
-        if [ -z "$pane_id" ]; then
+        if [ -z "$pane_info" ]; then
             continue
         fi
         
+        # Extract pane_id and window_id
+        pane_id="$(echo "$pane_info" | cut -d' ' -f1)"
+        window_id="$(echo "$pane_info" | cut -d' ' -f2)"
+        
         # Record original location for restoration
-        echo "$pane_id $session 0 $branch" >> "$DASHBOARD_RESTORE_MAP"
+        echo "$pane_id $session $window_id $branch" >> "$DASHBOARD_RESTORE_MAP"
         
         # Set pane title to show branch name
         tmux select-pane -t "$pane_id" -T "$branch"

--- a/lib/dashboard.sh
+++ b/lib/dashboard.sh
@@ -25,8 +25,10 @@ create_dashboard_session() {
     # Create dashboard session in background
     tmux new-session -d -s "$DASHBOARD_SESSION" -c "$(pwd)" || return 1
     
-    # Set up dashboard keybinding to exit
-    tmux bind-key -T root q run-shell "hydra dashboard-exit"
+    # Set up dashboard keybinding to exit - only works when in dashboard session
+    tmux bind-key -T root q if-shell '[ "#{session_name}" = "hydra-dashboard" ]' \
+        'run-shell "/usr/local/bin/hydra dashboard-exit"' \
+        'send-keys q'
     
     return 0
 }
@@ -203,6 +205,9 @@ cleanup_dashboard() {
     if tmux_session_exists "$DASHBOARD_SESSION"; then
         tmux kill-session -t "$DASHBOARD_SESSION" 2>/dev/null || true
     fi
+    
+    # Clean up the q key binding
+    tmux unbind-key -T root q 2>/dev/null || true
     
     # Clean up any remaining files
     rm -f "$DASHBOARD_RESTORE_MAP"


### PR DESCRIPTION
## Summary
- Fixed pane restoration failures when exiting dashboard
- Made q key binding session-specific to prevent affecting other sessions
- Added proper cleanup of key bindings on dashboard exit

## Problem
Two issues were discovered with the dashboard functionality:

1. **Pane restoration failure**: When exiting the dashboard, users would see "Failed to restore pane" warnings. This was caused by the dashboard hardcoding window ID to 0 when collecting panes, which failed when panes were from windows other than 0.

2. **Global q key binding**: The q key was bound globally, causing it to exit/detach from any tmux session, not just the dashboard. This was unexpected behavior that could disrupt normal workflow.

## Solution
This PR contains two targeted fixes:

### Fix 1: Capture correct window ID for pane restoration
- Modified pane collection to capture the actual window ID using `#{window_id}`
- Store the correct window ID in the restoration map
- Ensures panes are restored to their original windows

### Fix 2: Make q key binding session-specific
- Added conditional check so q only triggers dashboard-exit in the "hydra-dashboard" session
- In other sessions, q behaves as a normal key press
- Added cleanup to unbind the q key when dashboard exits

## Test plan
- [x] All existing tests pass
- [x] Manual testing confirms pane restoration works correctly
- [x] Manual testing confirms q key only exits dashboard when in dashboard session
- [x] Linting passes (POSIX-compliant)