### PR TITLE
Fix test hanging in non-interactive mode

### DIFF
--- a/lib/git.sh
+++ b/lib/git.sh
@@ -175,17 +175,24 @@ delete_worktree() {
     
     # Check for untracked files (optional warning)
     if [ -n "$(git -C "$path" ls-files --others --exclude-standard -- 2>/dev/null)" ]; then
-        echo "Warning: Worktree has untracked files" >&2
-        printf "Continue anyway? [y/N] "
-        read -r response
-        case "$response" in
-            [yY][eE][sS]|[yY])
-                ;;
-            *)
-                echo "Aborted" >&2
-                return 1
-                ;;
-        esac
+        # Check if we're in non-interactive mode
+        if [ -z "${HYDRA_NONINTERACTIVE:-}" ] && [ -z "${CI:-}" ]; then
+            # Interactive mode - prompt user
+            echo "Warning: Worktree has untracked files" >&2
+            printf "Continue anyway? [y/N] "
+            read -r response
+            case "$response" in
+                [yY][eE][sS]|[yY])
+                    ;;
+                *)
+                    echo "Aborted" >&2
+                    return 1
+                    ;;
+            esac
+        else
+            # Non-interactive mode - proceed with warning
+            echo "Warning: Worktree has untracked files (proceeding in non-interactive mode)" >&2
+        fi
     fi
     
     # Remove the worktree


### PR DESCRIPTION
## Summary
- Fixed test hanging issue where `delete_worktree()` would wait indefinitely for user input
- Added support for non-interactive mode in git worktree deletion
- Tests now complete successfully without hanging

## Problem
The integration test `test_issue_branch_cleanup` was hanging at the line "Killing test branch 'issue-999-test-cleanup-*'". Investigation revealed that the `delete_worktree()` function in `lib/git.sh` has an interactive prompt for untracked files that didn't respect the `HYDRA_NONINTERACTIVE` environment variable set by tests.

## Solution
Modified `delete_worktree()` to check for both `HYDRA_NONINTERACTIVE` and `CI` environment variables before showing any interactive prompts. When in non-interactive mode, the function now:
- Skips the prompt entirely
- Proceeds with deletion automatically
- Logs a warning to stderr about the automatic decision

## Changes
- Updated `lib/git.sh`: Wrapped the untracked files prompt (lines 176-189) with non-interactive mode checks

## Testing
- ✅ All tests pass (`make test` shows 0 failures)
- ✅ The specific `test_issue_branch_cleanup` test now completes without hanging
- ✅ POSIX-compliant (passes shellcheck and dash validation)
- ✅ Backward compatible - interactive mode still works as before

## Test Output
```
Testing issue branch spawn and kill cycle...
  Creating test branch 'issue-999-test-cleanup-1751495608'...
✓ Worktree directory was created at expected location
✓ Branch appears in git worktree list
  Killing test branch 'issue-999-test-cleanup-1751495608'...
  Kill output: Killing hydra head 'issue-999-test-cleanup-1751495608' (session: issue-999-test-cleanup-1751495608) [non-interactive mode]
Killing tmux session 'issue-999-test-cleanup-1751495608'...
Removing worktree at '/Users/sws/Code/hydra-issue-999-test-cleanup-1751495608'...
Hydra head 'issue-999-test-cleanup-1751495608' has been killed
  Kill exit code: 0
✓ hydra kill should succeed
✓ Worktree directory was successfully removed
```

The test now properly runs in non-interactive mode and completes successfully.