### PR TITLE
fix: resolve hydra library path issues when running inside sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,10 +193,24 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed development guidelines.
 
 **Environment Variables:**
 - `HYDRA_HOME`: Directory for runtime files (default: `~/.hydra`)
+- `HYDRA_AI_COMMAND`: Default AI tool to use (default: `claude`)
+- `HYDRA_ROOT`: Override hydra installation path for library discovery (useful when running from source)
 
 ## Performance
 
 Hydra targets <100ms switch latency. Run `hydra doctor` to test your system's performance and identify any bottlenecks.
+
+## Troubleshooting
+
+### Hydra commands fail inside hydra sessions
+
+If you're running hydra from source and commands like `hydra list` fail when run from inside a hydra-managed session, this is likely due to library path resolution issues. Solutions:
+
+1. **Install hydra system-wide**: Run `make install` to install hydra to `/usr/local/bin`
+2. **Set HYDRA_ROOT**: Export `HYDRA_ROOT=/path/to/hydra` pointing to your hydra source directory
+3. **Use absolute paths**: Call hydra using its full path instead of relying on PATH
+
+The issue occurs because hydra sessions run in git worktrees that don't contain the library files needed by the hydra script.
 
 ## License
 

--- a/bin/hydra
+++ b/bin/hydra
@@ -14,13 +14,44 @@ HYDRA_MAP="$HYDRA_HOME/map"
 HYDRA_VERSION="1.1.0-dev"
 
 # Source helper libraries
-# Detect if we're running from source or installed
-if [ -f "$(dirname "$0")/../lib/git.sh" ]; then
-    # Running from source directory
-    HYDRA_LIB_DIR="$(dirname "$0")/../lib"
+# Enhanced library detection with multiple fallback paths
+# Try to resolve the real path of the hydra binary
+HYDRA_BIN_PATH="$0"
+if [ -L "$HYDRA_BIN_PATH" ]; then
+    # Follow symlinks if possible (POSIX-compliant approach)
+    if command -v readlink >/dev/null 2>&1; then
+        # Try GNU readlink -f first, then BSD readlink
+        HYDRA_BIN_PATH="$(readlink -f "$HYDRA_BIN_PATH" 2>/dev/null || readlink "$HYDRA_BIN_PATH" 2>/dev/null || echo "$HYDRA_BIN_PATH")"
+    fi
+fi
+
+# Get the directory containing the hydra binary
+if HYDRA_BIN_DIR="$(cd "$(dirname "$HYDRA_BIN_PATH")" 2>/dev/null && pwd)"; then
+    : # Successfully got absolute path
 else
-    # Running from installed location
+    # Fallback to dirname if cd fails
+    HYDRA_BIN_DIR="$(dirname "$HYDRA_BIN_PATH")"
+fi
+
+# Try multiple paths to find the library directory
+if [ -d "$HYDRA_BIN_DIR/../lib" ] && [ -f "$HYDRA_BIN_DIR/../lib/git.sh" ]; then
+    # Running from source - resolve to absolute path
+    HYDRA_LIB_DIR="$(cd "$HYDRA_BIN_DIR/../lib" && pwd)"
+elif [ -d "/usr/local/lib/hydra" ] && [ -f "/usr/local/lib/hydra/git.sh" ]; then
+    # Installed location
     HYDRA_LIB_DIR="/usr/local/lib/hydra"
+elif [ -n "${HYDRA_ROOT:-}" ] && [ -d "$HYDRA_ROOT/lib" ] && [ -f "$HYDRA_ROOT/lib/git.sh" ]; then
+    # Environment variable override
+    HYDRA_LIB_DIR="$HYDRA_ROOT/lib"
+else
+    echo "Error: Cannot find hydra library directory" >&2
+    echo "Searched in:" >&2
+    echo "  - $HYDRA_BIN_DIR/../lib (source)" >&2
+    echo "  - /usr/local/lib/hydra (installed)" >&2
+    [ -n "${HYDRA_ROOT:-}" ] && echo "  - $HYDRA_ROOT/lib (HYDRA_ROOT)" >&2
+    echo "" >&2
+    echo "Please ensure hydra is properly installed or set HYDRA_ROOT environment variable" >&2
+    exit 1
 fi
 
 # shellcheck source=../lib/git.sh
@@ -95,6 +126,7 @@ Examples:
 Environment:
   HYDRA_HOME        Directory for runtime files (default: ~/.hydra)
   HYDRA_AI_COMMAND  Default AI tool (default: claude)
+  HYDRA_ROOT        Override hydra installation path (for library discovery)
 EOF
 }
 


### PR DESCRIPTION
## Summary
- Enhanced library path detection to work from any location, including from within hydra-managed sessions
- Added support for HYDRA_ROOT environment variable for flexible library discovery
- Fixed issue where commands like 'hydra list' would fail when run from inside a hydra session

## Problem
When hydra is run from source (not installed via `make install`), commands fail when executed from within a hydra-managed tmux session. This happens because:
- Hydra sessions run in git worktrees at `../hydra-branch/` relative to the main repo
- The library detection uses relative path `../lib` which doesn't exist in worktree directories
- This causes the script to fail with "Cannot find hydra library directory"

## Solution
Implemented robust path resolution that:
1. Follows symlinks to find the actual hydra binary location
2. Tries multiple fallback paths for library discovery
3. Supports HYDRA_ROOT environment variable override
4. Works correctly whether running from source, installed location, or within sessions

## Changes
- Modified library detection logic in `/bin/hydra` to be more robust
- Added HYDRA_ROOT environment variable support
- Updated documentation with troubleshooting section
- Updated help text to include new environment variable

## Testing
- Verified hydra works from source directory
- Verified hydra works from different directories
- Tested with HYDRA_ROOT environment variable
- Ensured POSIX compliance (shellcheck passes)
- All existing tests continue to pass

## Documentation
- Added HYDRA_ROOT to README environment variables section
- Created troubleshooting section explaining the issue and solutions
- Updated command help text

Fixes the issue where hydra commands fail inside hydra-managed sessions.