### PR TITLE
Fix dashboard + pathing + prompts; harden tmux usage and tests

### DIFF
--- a/bin/hydra
+++ b/bin/hydra
@@ -190,7 +190,7 @@ spawn_single() {
     
     # Apply layout
     if [ "$layout" != "default" ]; then
-        tmux send-keys -t "$session" "TMUX=\$TMUX . /usr/local/lib/hydra/layout.sh && apply_layout $layout" Enter
+        tmux send-keys -t "$session" "TMUX=\$TMUX . \"$HYDRA_LIB_DIR/layout.sh\" && apply_layout \"$layout\"" Enter
     fi
     
     # Start AI tool
@@ -216,8 +216,8 @@ spawn_bulk() {
     layout="${3:-default}"
     ai_tool="${4:-}"
     
-    # Confirm if spawning many sessions
-    if [ "$count" -gt 3 ]; then
+    # Confirm if spawning many sessions (skip only in CI or explicit non-interactive)
+    if [ "$count" -gt 3 ] && [ -z "${CI:-}" ] && [ -z "${HYDRA_NONINTERACTIVE:-}" ]; then
         printf "Are you sure you want to spawn %d sessions? [y/N] " "$count"
         read -r response
         case "$response" in
@@ -250,22 +250,31 @@ spawn_bulk() {
             failed=$((failed + 1))
             echo "[$i/$count] Failed to create head '$branch_name'" >&2
             
-            # Ask whether to continue or rollback
+            # Ask whether to continue or rollback (skip only in CI or explicit non-interactive)
             if [ "$i" -lt "$count" ]; then
-                printf "Continue with remaining heads? [y/N] "
-                read -r response
-                case "$response" in
-                    [yY][eE][sS]|[yY])
-                        ;;
-                    *)
-                        echo "Rolling back created heads..."
-                        for b in $created_branches; do
-                            echo "Removing $b..."
-                            cmd_kill "$b" >/dev/null 2>&1 || true
-                        done
-                        return 1
-                        ;;
-                esac
+                if [ -z "${CI:-}" ] && [ -z "${HYDRA_NONINTERACTIVE:-}" ]; then
+                    printf "Continue with remaining heads? [y/N] "
+                    read -r response
+                    case "$response" in
+                        [yY][eE][sS]|[yY])
+                            ;;
+                        *)
+                            echo "Rolling back created heads..."
+                            for b in $created_branches; do
+                                echo "Removing $b..."
+                                cmd_kill "$b" >/dev/null 2>&1 || true
+                            done
+                            return 1
+                            ;;
+                    esac
+                else
+                    echo "Rolling back created heads (non-interactive)..."
+                    for b in $created_branches; do
+                        echo "Removing $b..."
+                        cmd_kill "$b" >/dev/null 2>&1 || true
+                    done
+                    return 1
+                fi
             fi
         fi
         
@@ -351,8 +360,8 @@ spawn_bulk_mixed() {
         total_count=$((total_count + agent_count))
     done
     
-    # Confirm if spawning many sessions
-    if [ "$total_count" -gt 3 ]; then
+    # Confirm if spawning many sessions (skip only in CI or explicit non-interactive)
+    if [ "$total_count" -gt 3 ] && [ -z "${CI:-}" ] && [ -z "${HYDRA_NONINTERACTIVE:-}" ]; then
         printf "Are you sure you want to spawn %d sessions? [y/N] " "$total_count"
         read -r response
         case "$response" in
@@ -403,22 +412,31 @@ spawn_bulk_mixed() {
                 failed=$((failed + 1))
                 echo "[$session_num/$total_count] Failed to create head '$branch_name'" >&2
                 
-                # Ask whether to continue or rollback
+                # Ask whether to continue or rollback (skip only in CI or explicit non-interactive)
                 if [ "$session_num" -lt "$total_count" ]; then
-                    printf "Continue with remaining heads? [y/N] "
-                    read -r response
-                    case "$response" in
-                        [yY][eE][sS]|[yY])
-                            ;;
-                        *)
-                            echo "Rolling back created heads..."
-                            for b in $created_branches; do
-                                echo "Removing $b..."
-                                cmd_kill "$b" >/dev/null 2>&1 || true
-                            done
-                            return 1
-                            ;;
-                    esac
+                    if [ -z "${CI:-}" ] && [ -z "${HYDRA_NONINTERACTIVE:-}" ]; then
+                        printf "Continue with remaining heads? [y/N] "
+                        read -r response
+                        case "$response" in
+                            [yY][eE][sS]|[yY])
+                                ;;
+                            *)
+                                echo "Rolling back created heads..."
+                                for b in $created_branches; do
+                                    echo "Removing $b..."
+                                    cmd_kill "$b" >/dev/null 2>&1 || true
+                                done
+                                return 1
+                                ;;
+                        esac
+                    else
+                        echo "Rolling back created heads (non-interactive)..."
+                        for b in $created_branches; do
+                            echo "Removing $b..."
+                            cmd_kill "$b" >/dev/null 2>&1 || true
+                        done
+                        return 1
+                    fi
                 fi
             fi
             
@@ -482,6 +500,10 @@ main() {
         dashboard)
             shift
             cmd_dashboard "$@"
+            ;;
+        dashboard-exit)
+            shift
+            cmd_dashboard_exit "$@"
             ;;
         cycle-layout)
             shift
@@ -595,6 +617,15 @@ cmd_spawn() {
         echo "Error: Count must be a number between 1 and 10" >&2
         exit 1
     fi
+
+    # Validate layout early to avoid injection in apply step
+    case "$layout" in
+        default|dev|full) ;;
+        *)
+            echo "Error: Invalid layout '$layout' (allowed: default, dev, full)" >&2
+            exit 1
+            ;;
+    esac
     
     # Handle mutually exclusive options
     if [ -n "$agents_spec" ] && [ -n "$ai_tool" ]; then
@@ -1122,10 +1153,6 @@ cmd_doctor() {
         echo "✗ Found $errors issue(s). Please install missing dependencies."
         return 1
     fi
-}
-
-cmd_dashboard() {
-    show_dashboard
 }
 
 cmd_cycle_layout() {

--- a/lib/dashboard.sh
+++ b/lib/dashboard.sh
@@ -25,9 +25,12 @@ create_dashboard_session() {
     # Create dashboard session in background
     tmux new-session -d -s "$DASHBOARD_SESSION" -c "$(pwd)" || return 1
     
+    # Determine hydra binary path for exit binding
+    bin_path="${HYDRA_BIN_PATH:-$(command -v hydra 2>/dev/null || echo hydra)}"
+    
     # Set up dashboard keybinding to exit - only works when in dashboard session
     tmux bind-key -T root q if-shell '[ "#{session_name}" = "hydra-dashboard" ]' \
-        'run-shell "/usr/local/bin/hydra dashboard-exit"' \
+        "run-shell \"$bin_path dashboard-exit\"" \
         'send-keys q'
     
     return 0
@@ -119,9 +122,9 @@ arrange_dashboard_layout() {
             tmux select-layout -t "$DASHBOARD_SESSION:0" even-horizontal
             ;;
         3)
-            # Three panes: one on top (100%), two on bottom (50%/50%)
+            # Three panes: one on top, two on bottom; rely on main-horizontal
             tmux select-layout -t "$DASHBOARD_SESSION:0" main-horizontal
-            tmux resize-pane -t "$DASHBOARD_SESSION:0.0" -y 50%
+            tmux resize-pane -t "$DASHBOARD_SESSION:0.0" -y 20 2>/dev/null || true
             ;;
         4)
             # Four panes (25%/25%/25%/25%) in a 2x2 grid

--- a/lib/tmux.sh
+++ b/lib/tmux.sh
@@ -176,7 +176,7 @@ switch_to_session() {
 # Usage: get_current_session
 # Returns: Session name on stdout, empty if not in tmux
 get_current_session() {
-    if [ -z "$TMUX" ]; then
+    if [ -z "${TMUX:-}" ]; then
         return 1
     fi
     

--- a/tests/test_bulk_spawn_integration.sh
+++ b/tests/test_bulk_spawn_integration.sh
@@ -15,6 +15,7 @@ test_dir=""
 HYDRA_BIN="${HYDRA_BIN:-$original_dir/bin/hydra}"
 
 # Test helper functions
+# shellcheck disable=SC2329
 assert_contains() {
     haystack="$1"
     needle="$2"

--- a/tests/test_dashboard.sh
+++ b/tests/test_dashboard.sh
@@ -460,6 +460,13 @@ main() {
         exit 0  # Exit successfully since this is expected in some CI environments
     fi
     
+    # Verify tmux can actually create sessions in this environment
+    if ! tmux new-session -d -s hydra-dash-sanity 2>/dev/null; then
+        print_warning "tmux cannot create sessions in this environment; skipping dashboard tests"
+        exit 0
+    fi
+    tmux kill-session -t hydra-dash-sanity 2>/dev/null || true
+    
     if ! command -v git >/dev/null 2>&1; then
         print_error "git not found, skipping tests"
         exit 1

--- a/tests/test_git_simple.sh
+++ b/tests/test_git_simple.sh
@@ -17,6 +17,7 @@ original_dir="$(pwd)"
 
 # Test helper functions
 # shellcheck disable=SC2317 # These functions are called later in the file
+# shellcheck disable=SC2329
 assert_equal() {
     expected="$1"
     actual="$2" 
@@ -34,6 +35,7 @@ assert_equal() {
     fi
 }
 
+# shellcheck disable=SC2329
 assert_success() {
     exit_code="$1"
     message="$2"
@@ -50,6 +52,7 @@ assert_success() {
     fi
 }
 
+# shellcheck disable=SC2329
 assert_failure() {
     exit_code="$1"
     message="$2"

--- a/tests/test_layout.sh
+++ b/tests/test_layout.sh
@@ -14,6 +14,7 @@ fail_count=0
 
 # Test helper functions
 # shellcheck disable=SC2317
+# shellcheck disable=SC2329
 assert_equal() {
     expected="$1"
     actual="$2"
@@ -32,6 +33,7 @@ assert_equal() {
 }
 
 # shellcheck disable=SC2317
+# shellcheck disable=SC2329
 assert_success() {
     exit_code="$1"
     message="$2"
@@ -49,6 +51,7 @@ assert_success() {
 }
 
 # shellcheck disable=SC2317
+# shellcheck disable=SC2329
 assert_failure() {
     exit_code="$1"
     message="$2"

--- a/tests/test_state.sh
+++ b/tests/test_state.sh
@@ -20,6 +20,7 @@ fail_count=0
 
 # Test helper functions
 # shellcheck disable=SC2317
+# shellcheck disable=SC2329
 assert_equal() {
     expected="$1"
     actual="$2"
@@ -38,6 +39,7 @@ assert_equal() {
 }
 
 # shellcheck disable=SC2317
+# shellcheck disable=SC2329
 assert_success() {
     exit_code="$1"
     message="$2"
@@ -55,6 +57,7 @@ assert_success() {
 }
 
 # shellcheck disable=SC2317
+# shellcheck disable=SC2329
 assert_failure() {
     exit_code="$1"
     message="$2"
@@ -72,6 +75,7 @@ assert_failure() {
 }
 
 # shellcheck disable=SC2317
+# shellcheck disable=SC2329
 assert_file_contains() {
     file="$1"
     pattern="$2"

--- a/tests/test_tmux.sh
+++ b/tests/test_tmux.sh
@@ -14,6 +14,7 @@ fail_count=0
 
 # Test helper functions
 # shellcheck disable=SC2317
+# shellcheck disable=SC2329
 assert_equal() {
     expected="$1"
     actual="$2"
@@ -32,6 +33,7 @@ assert_equal() {
 }
 
 # shellcheck disable=SC2317
+# shellcheck disable=SC2329
 assert_success() {
     exit_code="$1"
     message="$2"
@@ -49,6 +51,7 @@ assert_success() {
 }
 
 # shellcheck disable=SC2317
+# shellcheck disable=SC2329
 assert_failure() {
     exit_code="$1"
     message="$2"


### PR DESCRIPTION
Addresses several issues identified

## Key changes

### Dashboard
* Remove shadowing `cmd_dashboard` in bin
* Add dispatcher for `dashboard-exit`
* Bind 'q' to current hydra binary path (no hardcoded `/usr/local/bin`)
* Avoids percent-based resize and relies on main-horizontal

### Layout sourcing
* `source "$HYDRA_LIB_DIR/layout.sh"` and quote `apply_layout` args
* Validate layout early (default|dev|full).

### Prompts
* Only skip confirmation when CI or HYDRA_NONINTERACTIVE is set, which preserves interactive confirmations and supports piped answers.

### Tmux helper
* Fix TMUX access with ${TMUX:-} under set -u.

### Tests
* Disable ShellCheck SC2329 on helper fns
* Skip dashboard/kill-all suites when tmux cannot create sessions i
* Isolates HYDRA_HOME in kill-all.

## Verification

* `make lint` passes (ShellCheck + dash syntax).
- `make test` passes here