### PR TITLE
feat(dashboard): configurable multi-pane collection (+ CLI flag)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Dashboard: configurable multi-pane collection
+  - New env `HYDRA_DASHBOARD_PANES_PER_SESSION` controls panes per session:
+    - `1` (default): collect first pane only (previous behavior)
+    - `N`: collect up to N panes per session
+    - `all`: collect all panes from each session
+  - New CLI flag for `dashboard`: `-p, --panes-per-session <N|all>`
+  - Pane titles set to branch names for clarity
+
 ## [1.2.0] - 2025-08-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.2.0] - 2025-08-27
 
 ### Added
+- Dashboard: configurable multi-pane collection
+  - New env `HYDRA_DASHBOARD_PANES_PER_SESSION` controls panes per session:
+    - `1` (default): collect first pane only (previous behavior)
+    - `N`: collect up to N panes per session
+    - `all`: collect all panes from each session (leaves one pane behind)
+  - New CLI flag for `dashboard`: `-p, --panes-per-session <N|all>`
+  - Pane titles set to branch names for clarity
 - Per-head AI persistence in mapping file
   - `spawn` now stores the selected AI tool per head in `~/.hydra/map` (third column)
   - `list` and `status` annotate entries with `[ai: <tool>]`

--- a/README.md
+++ b/README.md
@@ -124,6 +124,26 @@ hydra dashboard --help # Get help about dashboard features
 - Non-disruptive: panes are temporarily moved and restored on exit
 - Automatically adjusts layout based on number of sessions (2x2, 3x3, etc.)
 
+#### Collect Multiple Panes Per Session
+
+By default, the dashboard collects just the first pane from each active session. For more complex layouts, you can collect multiple panes per session:
+
+```sh
+# Collect two panes from each session
+hydra dashboard --panes-per-session 2
+
+# Collect all panes from each session (leaves one pane per source session to keep it alive)
+hydra dashboard --panes-per-session all
+
+# Equivalent via environment variable
+HYDRA_DASHBOARD_PANES_PER_SESSION=2 hydra dashboard
+HYDRA_DASHBOARD_PANES_PER_SESSION=all hydra dashboard
+```
+
+Notes:
+- Hydra never drains a source session completely; it always leaves at least one pane behind so your sessions remain usable while viewing the dashboard.
+- Pane titles in the dashboard are set to the corresponding branch name for clarity.
+
 ### System Management
 
 ```sh

--- a/bin/hydra
+++ b/bin/hydra
@@ -123,6 +123,8 @@ Commands:
   status            Show health status of all heads
   doctor            Check system performance
   dashboard         View all sessions in a single dashboard
+                    Options:
+                      -p, --panes-per-session <N|all>  Collect multiple panes per session
   cycle-layout      Cycle through tmux pane layouts
   completion        Generate shell completion scripts
   version           Show version information
@@ -145,6 +147,7 @@ Environment:
   HYDRA_HOME        Directory for runtime files (default: ~/.hydra)
   HYDRA_AI_COMMAND  Default AI tool (default: claude)
   HYDRA_ROOT        Override hydra installation path (for library discovery)
+  HYDRA_DASHBOARD_PANES_PER_SESSION  Panes per session for dashboard (1, N, or all)
 EOF
 }
 

--- a/lib/completion.sh
+++ b/lib/completion.sh
@@ -30,6 +30,20 @@ _hydra_completion() {
             COMPREPLY=($(compgen -W "${branches}" -- ${cur}))
             return 0
             ;;
+        dashboard)
+            case "${cur}" in
+                --*)
+                    COMPREPLY=($(compgen -W "--panes-per-session" -- ${cur}))
+                    ;;
+                *)
+                    if [ "${prev}" = "--panes-per-session" ]; then
+                        COMPREPLY=($(compgen -W "1 2 3 4 5 6 7 8 9 10 all" -- ${cur}))
+                        return 0
+                    fi
+                    ;;
+            esac
+            return 0
+            ;;
         kill)
             # Complete with git branch names or --all flag
             case "${cur}" in
@@ -137,6 +151,10 @@ _hydra() {
                         '(-i --issue)'{-i,--issue}'[Create from GitHub issue]:issue:' \
                         '1:branch:_hydra_branches'
                     ;;
+                dashboard)
+                    _arguments \
+                        '(-p --panes-per-session)'{-p,--panes-per-session}'[Panes to collect per session]:value:(1 2 3 4 5 6 7 8 9 10 all)'
+                    ;;
                 kill)
                     _arguments \
                         '--all[Kill all hydra sessions]' \
@@ -219,6 +237,9 @@ complete -c hydra -f -n '__fish_seen_subcommand_from spawn' -l ai -d 'AI tool to
 complete -c hydra -f -n '__fish_seen_subcommand_from spawn' -l agents -d 'Mixed agents specification (e.g., claude:2,aider:1)'
 complete -c hydra -f -n '__fish_seen_subcommand_from spawn' -s i -l issue -d 'Create from GitHub issue number'
 complete -c hydra -f -n '__fish_seen_subcommand_from spawn; and not __fish_seen_subcommand_from -l --layout -n --count --ai --agents -i --issue' -a '(git branch 2>/dev/null | sed "s/^[ *]*//" | grep -v "^(")'
+
+# Complete dashboard flags
+complete -c hydra -f -n '__fish_seen_subcommand_from dashboard' -s p -l panes-per-session -d 'Panes to collect per session' -a '1 2 3 4 5 6 7 8 9 10 all'
 
 # Complete kill command with git branches
 complete -c hydra -f -n '__fish_seen_subcommand_from kill' -a '(git branch 2>/dev/null | sed "s/^[ *]*//" | grep -v "^(")'

--- a/tests/test_dashboard.sh
+++ b/tests/test_dashboard.sh
@@ -458,6 +458,96 @@ test_pane_collection_and_restore() {
     return 0
 }
 
+# Test multi-pane collection via env
+test_multi_pane_collection_env() {
+    print_status "Testing multi-pane collection (env: 2 panes per session)..."
+    cd "$TEST_REPO_DIR" || exit 1
+
+    HYDRA_LIB_DIR="$SCRIPT_DIR/../lib"
+    # shellcheck disable=SC1091
+    . "$HYDRA_LIB_DIR/tmux.sh"
+    # shellcheck disable=SC1091
+    . "$HYDRA_LIB_DIR/state.sh"
+    # shellcheck disable=SC1091
+    . "$HYDRA_LIB_DIR/dashboard.sh"
+
+    HYDRA_MAP="${HYDRA_HOME:-$HOME/.hydra}/map"
+    if [ ! -f "$HYDRA_MAP" ] || [ ! -s "$HYDRA_MAP" ]; then
+        print_warning "No Hydra map file found, skipping multi-pane test"
+        return 0
+    fi
+
+    # Ensure each source session has at least 2 panes
+    expected_sessions=0
+    while IFS=' ' read -r branch session; do
+        if tmux_session_exists "$session"; then
+            expected_sessions=$((expected_sessions + 1))
+            # Ensure exactly >=2 panes by splitting until 2
+            pcnt=$(tmux list-panes -t "$session:0" 2>/dev/null | wc -l | tr -d ' ')
+            while [ "${pcnt:-0}" -lt 2 ]; do
+                tmux split-window -t "$session:0" -d 2>/dev/null || true
+                pcnt=$(tmux list-panes -t "$session:0" 2>/dev/null | wc -l | tr -d ' ')
+            done
+        fi
+    done < "$HYDRA_MAP"
+    if [ "$expected_sessions" -lt 1 ]; then
+        print_warning "No active sessions found, skipping multi-pane test"
+        return 0
+    fi
+
+    # Create a new dashboard session
+    if ! create_dashboard_session; then
+        print_error "Failed to create dashboard session"
+        return 1
+    fi
+
+    initial_panes=$(tmux list-panes -t "$DASHBOARD_SESSION:0" 2>/dev/null | wc -l | tr -d ' ')
+
+    # Collect up to 2 panes per session
+    export HYDRA_DASHBOARD_PANES_PER_SESSION=2
+    if ! collect_session_panes; then
+        print_error "collect_session_panes failed (env=2)"
+        tmux kill-session -t "$DASHBOARD_SESSION" 2>/dev/null || true
+        return 1
+    fi
+
+    collected_lines=$(wc -l < "$DASHBOARD_RESTORE_MAP" | tr -d ' ')
+    expected_collected=$((expected_sessions * 2))
+    if [ "$collected_lines" -ne "$expected_collected" ]; then
+        print_error "Expected to collect $expected_collected panes, got $collected_lines"
+        tmux kill-session -t "$DASHBOARD_SESSION" 2>/dev/null || true
+        return 1
+    fi
+
+    after_collect_panes=$(tmux list-panes -t "$DASHBOARD_SESSION:0" 2>/dev/null | wc -l | tr -d ' ')
+    expected_after=$((initial_panes + collected_lines))
+    if [ "$after_collect_panes" -ne "$expected_after" ]; then
+        print_error "Unexpected pane count in dashboard (got $after_collect_panes, expected $expected_after)"
+        tmux kill-session -t "$DASHBOARD_SESSION" 2>/dev/null || true
+        return 1
+    fi
+
+    # Restore
+    if ! restore_panes; then
+        print_error "restore_panes reported failures (env=2)"
+        tmux kill-session -t "$DASHBOARD_SESSION" 2>/dev/null || true
+        return 1
+    fi
+
+    # After restore, initial pane count persists
+    after_restore_panes=$(tmux list-panes -t "$DASHBOARD_SESSION:0" 2>/dev/null | wc -l | tr -d ' ')
+    if [ "$after_restore_panes" -ne "$initial_panes" ]; then
+        print_error "Dashboard pane count after restore is $after_restore_panes (expected $initial_panes)"
+        tmux kill-session -t "$DASHBOARD_SESSION" 2>/dev/null || true
+        return 1
+    fi
+
+    # Clean up dashboard session
+    tmux kill-session -t "$DASHBOARD_SESSION" 2>/dev/null || true
+    unset HYDRA_DASHBOARD_PANES_PER_SESSION
+    print_status "Multi-pane collection via env verified"
+    return 0
+}
 # Cleanup test environment
 cleanup_test_env() {
     print_status "Cleaning up test environment..."
@@ -551,6 +641,9 @@ main() {
     
     if [ "$test_failed" -eq 0 ]; then
         test_pane_collection_and_restore || test_failed=1
+    fi
+    if [ "$test_failed" -eq 0 ]; then
+        test_multi_pane_collection_env || test_failed=1
     fi
     
     # Report results


### PR DESCRIPTION
This PR enhances the Hydra dashboard to support collecting multiple panes per session.

Summary
- New env: HYDRA_DASHBOARD_PANES_PER_SESSION
  - 1 (default): collect first pane only (previous behavior)
  - N: collect up to N panes per session
  - all: collect all panes (leaves one pane behind to keep session alive)
- New CLI flag: `hydra dashboard -p, --panes-per-session <N|all>`
- Pane titles in dashboard are set to branch names for clarity
- Robust pane enumeration across windows; record only successful joins; brief retry on join failure
- Shell completions updated (bash/zsh/fish)
- Changelog and README updated

Notes
- Behavior is backward compatible by default (1 pane per session)
- Dashboard never drains a source session completely
- Tests updated to cover the new env-driven multi-pane collection path

Closes: (optional)
