### PR TITLE
fix(completion): add generate_completion dispatcher

### DIFF
--- a/bin/hydra
+++ b/bin/hydra
@@ -11,7 +11,7 @@ if [ -z "${HOME:-}" ] || [ ! -d "${HOME:-}" ]; then
 fi
 HYDRA_HOME="${HYDRA_HOME:-$HOME/.hydra}"
 HYDRA_MAP="$HYDRA_HOME/map"
-HYDRA_VERSION="1.2.0"
+HYDRA_VERSION="1.3.0"
 
 # Source helper libraries
 # Enhanced library detection with multiple fallback paths

--- a/lib/completion.sh
+++ b/lib/completion.sh
@@ -249,6 +249,31 @@ complete -c hydra -f -n '__fish_seen_subcommand_from switch' -a '(test -f "$HYDR
 EOF
 }
 
+# Dispatch completion generation by shell
+# Usage: generate_completion [bash|zsh|fish]
+# Returns: 0 on success, 1 on unsupported shell
+generate_completion() {
+    shell="${1:-bash}"
+
+    case "$shell" in
+        bash)
+            generate_bash_completion
+            ;;
+        zsh)
+            generate_zsh_completion
+            ;;
+        fish)
+            generate_fish_completion
+            ;;
+        *)
+            echo "Error: Unsupported shell '$shell'. Supported shells: bash, zsh, fish" >&2
+            return 1
+            ;;
+    esac
+
+    return 0
+}
+
 # Install completion scripts
 # Usage: install_completions [bash|zsh|fish]
 # Returns: 0 on success, 1 on failure

--- a/tests/test_completion.sh
+++ b/tests/test_completion.sh
@@ -1,0 +1,74 @@
+#!/bin/sh
+# Unit tests for completion dispatcher in lib/completion.sh via bin/hydra
+# POSIX-compliant tests
+
+# Test framework setup
+test_count=0
+pass_count=0
+fail_count=0
+
+# Common test helpers
+# shellcheck source=./helpers.sh
+# shellcheck disable=SC1091
+. "$(dirname "$0")/helpers.sh"
+
+# Local helper to assert non-empty string
+# shellcheck disable=SC2317
+assert_nonempty() {
+    value="$1"
+    message="$2"
+
+    test_count=$((test_count + 1))
+    if [ -n "$value" ]; then
+        pass_count=$((pass_count + 1))
+        echo "✓ $message"
+    else
+        fail_count=$((fail_count + 1))
+        echo "✗ $message"
+        echo "  Got empty output"
+    fi
+}
+
+HYDRA_NONINTERACTIVE=1
+export HYDRA_NONINTERACTIVE
+
+echo "Running completion dispatcher tests..."
+echo "====================================="
+
+# Test bash completion generation
+out="$(HYDRA_HOME="$(mktemp -d)" bin/hydra completion bash 2>/dev/null)"
+rc=$?
+assert_success "$rc" "hydra completion bash should succeed"
+assert_nonempty "$out" "bash completion output should be non-empty"
+
+# Test zsh completion generation
+out="$(HYDRA_HOME="$(mktemp -d)" bin/hydra completion zsh 2>/dev/null)"
+rc=$?
+assert_success "$rc" "hydra completion zsh should succeed"
+assert_nonempty "$out" "zsh completion output should be non-empty"
+
+# Test fish completion generation
+out="$(HYDRA_HOME="$(mktemp -d)" bin/hydra completion fish 2>/dev/null)"
+rc=$?
+assert_success "$rc" "hydra completion fish should succeed"
+assert_nonempty "$out" "fish completion output should be non-empty"
+
+# Test unknown shell returns failure
+out="$(HYDRA_HOME="$(mktemp -d)" bin/hydra completion unknown 2>/dev/null)"
+rc=$?
+assert_failure "$rc" "hydra completion unknown should fail"
+
+echo "====================================="
+echo "Test Results:"
+echo "Total:  $test_count"
+echo "Passed: $pass_count"
+echo "Failed: $fail_count"
+
+if [ "$fail_count" -eq 0 ]; then
+    echo "All tests passed!"
+    exit 0
+else
+    echo "Some tests failed!"
+    exit 1
+fi
+


### PR DESCRIPTION
This fixes missing shell completion dispatcher.
- Adds POSIX `generate_completion` that dispatches to bash/zsh/fish
- Defaults to bash, errors clearly on unsupported shells
- Adds tests covering bash, zsh, fish, and unknown shell

Closes #34