### PR TITLE
feat(procfile): optional Procfile-based process orchestration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-<!-- Nothing yet -->
+### Added
+- Optional Procfile-based process orchestration
+  - When no YAML config is present, Hydra can read a Procfile and launch each entry in its own tmux window (e.g., `proc-web`, `proc-worker`).
+  - Procfile search precedence: worktree `Procfile` → worktree `/.hydra/Procfile` → repo `/.hydra/Procfile` → `~/.hydra/Procfile`.
+  - Guards: `HYDRA_DISABLE_PROCFILE=1` disables; `HYDRA_REGENERATE_RUN_PROCFILE` controls regenerate behavior (on by default).
+  - Customizable window name prefix via `HYDRA_PROCFILE_WINDOW_PREFIX` (default: `proc`).
 
 ## [1.2.0] - 2025-08-30
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,30 @@ startup:
 - On spawn/regenerate: windows and panes are applied. `startup` runs on spawn, and on regenerate only if `HYDRA_REGENERATE_RUN_STARTUP=1`.
 - Minimal parser supports the fields above; values are plain strings.
 
+## Procfile (optional)
+
+If no YAML config is present, Hydra can auto-launch common processes from a Procfile when a head is spawned.
+
+- File locations (checked in order):
+  - `./Procfile`
+  - `./.hydra/Procfile`
+  - `<repo>/.hydra/Procfile`
+  - `~/.hydra/Procfile`
+- Format: one process per line: `name: command`
+
+Example:
+
+```
+web: npm run dev
+worker: bin/worker
+postgres: docker compose up db
+```
+
+- Each entry runs in its own tmux window named `proc-<name>` within the head’s session.
+- Disable at spawn/regenerate with `HYDRA_DISABLE_PROCFILE=1`.
+- Window prefix can be customized via `HYDRA_PROCFILE_WINDOW_PREFIX` (default: `proc`).
+- YAML takes precedence: if `.hydra/config.yml` exists, Procfile is ignored for that spawn/regenerate.
+
 ## Hooks (optional)
 
 Add `.hydra/` scripts to customize lifecycle:

--- a/bin/hydra
+++ b/bin/hydra
@@ -81,6 +81,9 @@ fi
 # shellcheck source=../lib/yaml.sh
 # shellcheck disable=SC1091
 . "$HYDRA_LIB_DIR/yaml.sh"
+# shellcheck source=../lib/procfile.sh
+# shellcheck disable=SC1091
+. "$HYDRA_LIB_DIR/procfile.sh"
 
 # Export paths for downstream helpers (e.g., safe tmux run-shell bindings)
 export HYDRA_LIB_DIR
@@ -112,6 +115,9 @@ Commands:
                       -n, --count <number>     Spawn multiple sessions (1-10)
                       --ai <tool>              Specify AI tool (claude, aider, gemini, etc.)
                       --agents <spec>          Mixed agents (e.g., "claude:2,aider:1")
+                    Notes:
+                      - If a YAML config is present (.hydra/config.yml), it defines windows/panes.
+                      - Otherwise, if a Procfile is present, Hydra launches processes per entry.
   spawn --issue <#> Create a head from a GitHub issue
   list              List all active Hydra heads
   switch            Switch to a different head (interactive)
@@ -220,6 +226,12 @@ spawn_single() {
         apply_custom_layout_or_default "$layout" "$session" "$worktree_path" "$repo_root"
         # Send optional startup commands
         run_startup_commands "$session" "$worktree_path" "$repo_root"
+        # Launch processes from Procfile if present and not disabled
+        if [ -z "${HYDRA_DISABLE_PROCFILE:-}" ]; then
+            if pfpath="$(locate_procfile "$worktree_path" "$repo_root" 2>/dev/null || true)" && [ -n "$pfpath" ]; then
+                run_procfile "$pfpath" "$session" "$worktree_path" "$repo_root"
+            fi
+        fi
     fi
     
     # Start AI tool unless explicitly skipped (e.g., demos/CI)
@@ -1072,6 +1084,12 @@ cmd_regenerate() {
                 # Optionally run startup commands on regenerate only if explicitly enabled
                 if [ -n "${HYDRA_REGENERATE_RUN_STARTUP:-}" ]; then
                     run_startup_commands "$session" "$dir" "$repo_root_for_dir"
+                fi
+                # Optionally run Procfile on regenerate (default on)
+                if [ -z "${HYDRA_DISABLE_PROCFILE:-}" ] && [ -n "${HYDRA_REGENERATE_RUN_PROCFILE:-1}" ]; then
+                    if pfpath="$(locate_procfile "$dir" "$repo_root_for_dir" 2>/dev/null || true)" && [ -n "$pfpath" ]; then
+                        run_procfile "$pfpath" "$session" "$dir" "$repo_root_for_dir"
+                    fi
                 fi
             fi
             # Optionally auto-launch stored AI tool in the regenerated session

--- a/lib/procfile.sh
+++ b/lib/procfile.sh
@@ -1,0 +1,74 @@
+#!/bin/sh
+# Procfile support for Hydra
+# POSIX-compliant shell script
+
+# Locate a Procfile with simple precedence
+# Usage: locate_procfile <worktree> <repo_root>
+# Echoes absolute path or nothing
+locate_procfile() {
+    wt="$1"; repo="$2"
+    # Precedence: worktree/Procfile -> worktree/.hydra/Procfile -> repo/.hydra/Procfile -> HYDRA_HOME/Procfile
+    if [ -n "$wt" ] && [ -f "$wt/Procfile" ]; then
+        echo "$wt/Procfile"; return 0
+    fi
+    if [ -n "$wt" ] && [ -f "$wt/.hydra/Procfile" ]; then
+        echo "$wt/.hydra/Procfile"; return 0
+    fi
+    if [ -n "$repo" ] && [ -f "$repo/.hydra/Procfile" ]; then
+        echo "$repo/.hydra/Procfile"; return 0
+    fi
+    if [ -n "${HYDRA_HOME:-}" ] && [ -f "$HYDRA_HOME/Procfile" ]; then
+        echo "$HYDRA_HOME/Procfile"; return 0
+    fi
+    return 1
+}
+
+# Sanitize a name for tmux window usage: keep [A-Za-z0-9_-], replace others with _
+_hydra_sanitize_name() {
+    printf '%s' "$1" | sed 's/[^a-zA-Z0-9_-]/_/g'
+}
+
+# Run processes from a Procfile into tmux windows
+# Format: "name: command"
+# Usage: run_procfile <procfile_path> <session> <worktree> <repo_root>
+run_procfile() {
+    pf="$1"; session="$2"; wt="$3"; _repo="$4"
+    [ -f "$pf" ] || return 0
+
+    prefix="${HYDRA_PROCFILE_WINDOW_PREFIX:-proc}"
+
+    # Read each non-empty, non-comment line
+    while IFS= read -r line || [ -n "$line" ]; do
+        # Trim whitespace
+        trimmed="$(printf '%s' "$line" | sed 's/^\s*//;s/\s*$//')"
+        [ -z "$trimmed" ] && continue
+        case "$trimmed" in
+            \#*) continue ;;
+        esac
+        # Expect pattern: name: command
+        case "$trimmed" in
+            *:*)
+                name="${trimmed%%:*}"
+                cmd="${trimmed#*:}"
+                # Trim again
+                name="$(printf '%s' "$name" | sed 's/^\s*//;s/\s*$//')"
+                cmd="$(printf '%s' "$cmd" | sed 's/^\s*//;s/\s*$//')"
+                ;;
+            *)
+                # Ignore invalid lines
+                continue
+                ;;
+        esac
+        [ -z "$name" ] && continue
+        [ -z "$cmd" ] && continue
+        safe_name="$(_hydra_sanitize_name "$name")"
+        win_name="$prefix-$safe_name"
+        # Create a new window for the process; ignore errors but try best-effort
+        tmux new-window -t "$session:" -n "$win_name" -c "$wt" 2>/dev/null || true
+        # Send command to the window
+        tmux send-keys -t "$session:$win_name" "$cmd" Enter 2>/dev/null || true
+    done < "$pf"
+
+    return 0
+}
+

--- a/tests/test_procfile.sh
+++ b/tests/test_procfile.sh
@@ -1,0 +1,93 @@
+#!/bin/sh
+# Tests for Procfile-based process launching
+
+test_count=0
+pass_count=0
+fail_count=0
+
+HYDRA_BIN="$(cd "$(dirname "$0")/.." && pwd)/bin/hydra"
+
+assert_true() {
+    cond="$1"
+    msg="$2"
+    test_count=$((test_count + 1))
+    if eval "$cond"; then
+        pass_count=$((pass_count + 1))
+        echo "✓ $msg"
+    else
+        fail_count=$((fail_count + 1))
+        echo "✗ $msg"
+    fi
+}
+
+setup() {
+    base_dir="$(mktemp -d)" || exit 1
+    repo_dir="$base_dir/repo"
+    mkdir -p "$repo_dir"
+    cd "$repo_dir" || exit 1
+    git init >/dev/null 2>&1
+    git config user.email test@example.com
+    git config user.name "Test User"
+    printf '%s\n' one > one.txt
+    git add one.txt
+    git commit -m init >/dev/null 2>&1
+    mkdir -p .hydra
+    export HYDRA_HOME="$base_dir/.hydra"
+    mkdir -p "$HYDRA_HOME"
+}
+
+teardown() {
+    # kill sessions created by this test
+    tmux list-sessions -F '#{session_name}' 2>/dev/null | grep '^pf-' | while read -r s; do
+        tmux kill-session -t "$s" 2>/dev/null || true
+    done
+    tmux list-sessions -F '#{session_name}' 2>/dev/null | grep '^pfguard-' | while read -r s; do
+        tmux kill-session -t "$s" 2>/dev/null || true
+    done
+    rm -rf "$base_dir"
+}
+
+echo "Testing Procfile process launch..."
+
+# Skip if tmux is not available
+if ! command -v tmux >/dev/null 2>&1; then
+    echo "⚠ tmux not available - skipping Procfile tests"
+    echo "Test Results:"
+    echo "  Total: 0"
+    echo "  Passed: 0"
+    echo "  Failed: 0"
+    exit 0
+fi
+
+setup
+
+# Create a Procfile in project config
+cat > .hydra/Procfile <<'PF'
+web: echo web
+worker: echo worker
+PF
+
+# Spawn a head; expect two process windows
+"$HYDRA_BIN" spawn pf-test >/dev/null 2>&1 || true
+
+assert_true "tmux list-windows -t pf-test 2>/dev/null | grep -q 'proc-web'" "proc-web window created"
+assert_true "tmux list-windows -t pf-test 2>/dev/null | grep -q 'proc-worker'" "proc-worker window created"
+
+# Guard: disabling Procfile should result in single default window
+HYDRA_DISABLE_PROCFILE=1 "$HYDRA_BIN" spawn pfguard-test >/dev/null 2>&1 || true
+assert_true "[ \"$(tmux list-windows -t pfguard-test 2>/dev/null | wc -l | tr -d ' ')\" -eq 1 ]" "Procfile disabled yields single window"
+
+teardown
+
+echo ""
+echo "Test Results:"
+echo "  Total:  $test_count"
+echo "  Passed: $pass_count"
+echo "  Failed: $fail_count"
+
+if [ "$fail_count" -gt 0 ]; then
+    exit 1
+else
+    exit 0
+fi
+


### PR DESCRIPTION
This PR adds optional Procfile-based process orchestration to Hydra.

Summary
- New module `lib/procfile.sh` with:
  - `locate_procfile` to discover a Procfile in worktree/.hydra/repo/.hydra/HYDRA_HOME
  - `run_procfile` to launch each `name: command` entry into its own tmux window (default prefix `proc-`)
- Integration points:
  - `spawn`: if no YAML config is present, after layout and startup commands, detect and run Procfile
  - `regenerate`: same precedence; can be disabled or controlled via env
- Guards and configuration:
  - `HYDRA_DISABLE_PROCFILE=1` disables Procfile launching
  - `HYDRA_REGENERATE_RUN_PROCFILE` controls regenerate behavior (default on)
  - `HYDRA_PROCFILE_WINDOW_PREFIX` customizes window name prefix (default `proc`)
- Documentation:
  - README section describing Procfile usage, precedence, env flags
  - CHANGELOG entry under Unreleased
- Tests:
  - `tests/test_procfile.sh` validates that Procfile creates expected windows and guard works

Rationale
Hydra currently does not orchestrate common app processes (dev server, worker, db). This brings parity with tools like Overmind by optionally reading a Procfile to make newly spawned heads immediately productive. YAML config still has priority for complex layouts.

Notes
- Backwards compatible; entirely opt-in when no Procfile exists.
- YAML `.hydra/config.yml` remains highest precedence and will bypass Procfile.

