### PR TITLE
feat(state): project-scoped mappings using repo identifiers; filter l…

### DIFF
--- a/bin/hydra
+++ b/bin/hydra
@@ -692,7 +692,7 @@ cmd_list() {
     echo "Active Hydra heads:"
     echo ""
     
-    # Read mapping file and display status
+    # Read per-repo mappings and display status
     while IFS=' ' read -r branch session ai; do
         # Check if session still exists
         if tmux_session_exists "$session"; then
@@ -718,7 +718,9 @@ cmd_list() {
                 echo "  $branch -> $session (dead)"
             fi
         fi
-    done < "$HYDRA_MAP"
+    done <<EOF
+$(list_mappings_current_repo)
+EOF
 }
 
 cmd_switch() {
@@ -732,11 +734,13 @@ cmd_switch() {
     if [ -n "${TMUX:-}" ]; then
         # Build session list for fzf or simple menu
         sessions=""
-        while IFS=' ' read -r branch session; do
+        while IFS=' ' read -r branch session _ai; do
             if tmux_session_exists "$session"; then
                 sessions="$sessions$branch ($session)\n"
             fi
-        done < "$HYDRA_MAP"
+        done <<EOF
+$(list_mappings_current_repo)
+EOF
         
         if [ -z "$sessions" ]; then
             echo "No active sessions found"
@@ -782,8 +786,8 @@ kill_all_sessions() {
         return 0
     fi
     
-    # Get all mappings
-    mappings="$(list_mappings)"
+    # Get all mappings for current repo
+    mappings="$(list_mappings_current_repo)"
     count="$(echo "$mappings" | wc -l | tr -d ' ')"
     
     if [ "$count" -eq 0 ]; then
@@ -793,7 +797,7 @@ kill_all_sessions() {
     
     # Display what will be killed
     echo "The following hydra heads will be killed:"
-    while IFS=' ' read -r branch session; do
+    while IFS=' ' read -r branch session _ai; do
         if [ -n "$branch" ] && [ -n "$session" ]; then
             echo "  $branch -> $session"
         fi
@@ -831,7 +835,7 @@ EOF
     failed=0
     
     # Process each mapping
-    while IFS=' ' read -r branch session; do
+    while IFS=' ' read -r branch session _ai; do
         if [ -z "$branch" ] || [ -z "$session" ]; then
             continue
         fi
@@ -1143,7 +1147,9 @@ cmd_status() {
             fi
             dead=$((dead + 1))
         fi
-    done < "$HYDRA_MAP"
+    done <<EOF
+$(list_mappings_current_repo)
+EOF
     
     echo ""
     echo "Summary:"

--- a/lib/state.sh
+++ b/lib/state.sh
@@ -2,7 +2,37 @@
 # State management functions for Hydra
 # POSIX-compliant shell script
 
-# Add a branch-session mapping
+# Compute a stable repo identifier for scoping (basename + 8-char sha1 of repo root)
+# Usage: get_current_repo_id
+# Echoes repo id or empty if not in a git repo
+get_current_repo_id() {
+    if git rev-parse --git-dir >/dev/null 2>&1; then
+        repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+        if [ -n "$repo_root" ]; then
+            base="$(basename "$repo_root")"
+            # sha1 via shasum or fallback to md5sum; as last resort, use path length hash
+            if command -v shasum >/dev/null 2>&1; then
+                h="$(printf '%s' "$repo_root" | shasum | awk '{print $1}' | cut -c1-8)"
+            elif command -v sha1sum >/dev/null 2>&1; then
+                h="$(printf '%s' "$repo_root" | sha1sum | awk '{print $1}' | cut -c1-8)"
+            elif command -v md5 >/dev/null 2>&1; then
+                h="$(printf '%s' "$repo_root" | md5 | awk '{print $1}' | cut -c1-8)"
+            elif command -v md5sum >/dev/null 2>&1; then
+                h="$(printf '%s' "$repo_root" | md5sum | awk '{print $1}' | cut -c1-8)"
+            else
+                # Very weak fallback hash
+                h="$(printf '%s' "$repo_root" | wc -c | tr -d ' ')"
+            fi
+            # Sanitize base and compose id without spaces
+            base_safe="$(printf '%s' "$base" | sed 's/[^a-zA-Z0-9_-]/_/g')"
+            printf '%s\n' "repo:${base_safe}-${h}"
+            return 0
+        fi
+    fi
+    return 1
+}
+
+# Add a branch-session mapping (scoped by current repo when available)
 # Usage: add_mapping <branch> <session> [ai_tool]
 # Returns: 0 on success, 1 on failure
 add_mapping() {
@@ -20,20 +50,34 @@ add_mapping() {
         return 1
     fi
     
-    # Remove existing mapping for this branch if any
+    # Remove existing mapping for this branch in this repo (best-effort)
     remove_mapping "$branch" 2>/dev/null || true
-    
-    # Add new mapping (optionally with AI tool)
-    if [ -n "$ai_tool" ]; then
-        echo "$branch $session $ai_tool" >> "$HYDRA_MAP"
+
+    # Determine repo id (optional)
+    repo_id=""
+    if repo_id_val="$(get_current_repo_id 2>/dev/null || true)" && [ -n "$repo_id_val" ]; then
+        repo_id="$repo_id_val"
+    fi
+
+    # Add new mapping (optionally with AI tool). Include repo id if available.
+    if [ -n "$repo_id" ]; then
+        if [ -n "$ai_tool" ]; then
+            echo "$repo_id $branch $session $ai_tool" >> "$HYDRA_MAP"
+        else
+            echo "$repo_id $branch $session" >> "$HYDRA_MAP"
+        fi
     else
-        echo "$branch $session" >> "$HYDRA_MAP"
+        if [ -n "$ai_tool" ]; then
+            echo "$branch $session $ai_tool" >> "$HYDRA_MAP"
+        else
+            echo "$branch $session" >> "$HYDRA_MAP"
+        fi
     fi
     
     return 0
 }
 
-# Remove a branch-session mapping
+# Remove a branch-session mapping for current repo
 # Usage: remove_mapping <branch>
 # Returns: 0 on success, 1 on failure
 remove_mapping() {
@@ -52,14 +96,26 @@ remove_mapping() {
     tmpfile="$(mktemp)" || return 1
     trap 'rm -f "$tmpfile"' EXIT INT TERM
     
-    # Filter out the branch; preserve optional AI column for others
-    while IFS=' ' read -r map_branch map_session map_ai; do
-        if [ "$map_branch" != "$branch" ]; then
-            suffix=""
-            [ -n "$map_ai" ] && suffix=" $map_ai"
-            echo "$map_branch $map_session$suffix"
-        fi
-    done < "$HYDRA_MAP" > "$tmpfile"
+    # Determine repo id (optional)
+    repo_id=""
+    if repo_id_val="$(get_current_repo_id 2>/dev/null || true)" && [ -n "$repo_id_val" ]; then
+        repo_id="$repo_id_val"
+    fi
+
+    # Filter out the branch for this repo; preserve others unchanged (using awk for robustness)
+    awk -v rid="$repo_id" -v target="$branch" '
+      BEGIN { OFS=" " }
+      NF==0 { next }
+      $1 ~ /^repo:/ {
+        if (rid != "" && $1 == rid && $2 == target) next
+        print $0
+        next
+      }
+      {
+        if ($1 == target) next
+        print $0
+      }
+    ' "$HYDRA_MAP" > "$tmpfile"
     
     # Replace original file
     mv "$tmpfile" "$HYDRA_MAP"
@@ -68,7 +124,7 @@ remove_mapping() {
     return 0
 }
 
-# Get session for a branch
+# Get session for a branch in current repo
 # Usage: get_session_for_branch <branch>
 # Returns: Session name on stdout, empty if not found
 get_session_for_branch() {
@@ -78,17 +134,36 @@ get_session_for_branch() {
         return 1
     fi
     
+    repo_id=""
+    if repo_id_val="$(get_current_repo_id 2>/dev/null || true)" && [ -n "$repo_id_val" ]; then
+        repo_id="$repo_id_val"
+    fi
+    # Prefer repo-scoped entries
+    while IFS=' ' read -r c1 c2 c3 c4; do
+        if [ -z "$c1" ]; then continue; fi
+        if [ "${c1#repo:}" != "$c1" ]; then
+            map_repo="$c1"; map_branch="$c2"; map_session="$c3"
+        else
+            map_repo=""; map_branch="$c1"; map_session="$c2"
+        fi
+        if [ -n "$repo_id" ] && [ "$map_repo" = "$repo_id" ] && [ "$map_branch" = "$branch" ]; then
+            printf '%s\n' "$map_session"; return 0
+        fi
+    done < "$HYDRA_MAP"
+    # Fallback to legacy entries if no repo-scoped mapping found
+    if [ -z "$repo_id" ]; then
+        return 1
+    fi
     while IFS=' ' read -r map_branch map_session _map_ai; do
         if [ "$map_branch" = "$branch" ]; then
-            echo "$map_session"
-            return 0
+            printf '%s\n' "$map_session"; return 0
         fi
     done < "$HYDRA_MAP"
     
     return 1
 }
 
-# Get branch for a session
+# Get branch for a session in current repo
 # Usage: get_branch_for_session <session>
 # Returns: Branch name on stdout, empty if not found
 get_branch_for_session() {
@@ -98,19 +173,37 @@ get_branch_for_session() {
         return 1
     fi
     
+    repo_id=""
+    if repo_id_val="$(get_current_repo_id 2>/dev/null || true)" && [ -n "$repo_id_val" ]; then
+        repo_id="$repo_id_val"
+    fi
+    while IFS=' ' read -r c1 c2 c3 c4; do
+        if [ -z "$c1" ]; then continue; fi
+        if [ "${c1#repo:}" != "$c1" ]; then
+            map_repo="$c1"; map_branch="$c2"; map_session="$c3"
+        else
+            map_repo=""; map_branch="$c1"; map_session="$c2"
+        fi
+        if [ -n "$repo_id" ] && [ "$map_repo" = "$repo_id" ] && [ "$map_session" = "$session" ]; then
+            printf '%s\n' "$map_branch"; return 0
+        fi
+    done < "$HYDRA_MAP"
+    # Fallback to legacy lines
+    if [ -z "$repo_id" ]; then
+        return 1
+    fi
     while IFS=' ' read -r map_branch map_session _map_ai; do
         if [ "$map_session" = "$session" ]; then
-            echo "$map_branch"
-            return 0
+            printf '%s\n' "$map_branch"; return 0
         fi
     done < "$HYDRA_MAP"
     
     return 1
 }
 
-# List all mappings
+# List all mappings (raw; backward compatible)
 # Usage: list_mappings
-# Returns: List of "branch session" pairs on stdout
+# Returns: Raw contents of HYDRA_MAP on stdout
 list_mappings() {
     if [ -z "$HYDRA_MAP" ] || [ ! -f "$HYDRA_MAP" ]; then
         return 0
@@ -119,7 +212,34 @@ list_mappings() {
     cat "$HYDRA_MAP"
 }
 
-# Validate mappings against actual state
+# List mappings for current repo only, printing: "branch session" or "branch session ai"
+# Usage: list_mappings_current_repo
+list_mappings_current_repo() {
+    if [ -z "$HYDRA_MAP" ] || [ ! -f "$HYDRA_MAP" ]; then
+        return 0
+    fi
+    repo_id=""
+    if repo_id_val="$(get_current_repo_id 2>/dev/null || true)" && [ -n "$repo_id_val" ]; then
+        repo_id="$repo_id_val"
+    fi
+    while IFS=' ' read -r c1 c2 c3 c4; do
+        [ -z "$c1" ] && continue
+        if [ "${c1#repo:}" != "$c1" ]; then
+            map_repo="$c1"; map_branch="$c2"; map_session="$c3"; map_ai="$c4"
+        else
+            map_repo=""; map_branch="$c1"; map_session="$c2"; map_ai="$c3"
+        fi
+        if [ -n "$repo_id" ] && { [ "$map_repo" = "$repo_id" ] || [ -z "$map_repo" ]; }; then
+            if [ -n "$map_ai" ]; then
+                printf '%s %s %s\n' "$map_branch" "$map_session" "$map_ai"
+            else
+                printf '%s %s\n' "$map_branch" "$map_session"
+            fi
+        fi
+    done < "$HYDRA_MAP"
+}
+
+# Validate mappings for current repo against actual state
 # Usage: validate_mappings
 # Returns: 0 if all valid, 1 if inconsistencies found
 validate_mappings() {
@@ -128,25 +248,35 @@ validate_mappings() {
     fi
     
     errors=0
+    repo_id=""
+    if repo_id_val="$(get_current_repo_id 2>/dev/null || true)" && [ -n "$repo_id_val" ]; then
+        repo_id="$repo_id_val"
+    fi
     
-    while IFS=' ' read -r branch session _ai; do
-        # Check if branch exists
-        if ! git_branch_exists "$branch"; then
-            echo "Warning: Branch '$branch' no longer exists" >&2
-            errors=1
+    while IFS=' ' read -r c1 c2 c3 c4; do
+        [ -z "$c1" ] && continue
+        if [ "${c1#repo:}" != "$c1" ]; then
+            map_repo="$c1"; branch="$c2"; session="$c3"
+        else
+            map_repo=""; branch="$c1"; session="$c2"
         fi
-        
-        # Check if session exists
-        if ! tmux_session_exists "$session"; then
-            echo "Warning: Session '$session' no longer exists" >&2
-            errors=1
+        # Only validate entries for current repo id (skip others and legacy)
+        if [ -n "$repo_id" ] && [ "$map_repo" = "$repo_id" ]; then
+            if ! git_branch_exists "$branch"; then
+                echo "Warning: Branch '$branch' no longer exists" >&2
+                errors=1
+            fi
+            if ! tmux_session_exists "$session"; then
+                echo "Warning: Session '$session' no longer exists" >&2
+                errors=1
+            fi
         fi
     done < "$HYDRA_MAP"
     
     return $errors
 }
 
-# Clean up invalid mappings (preserving optional AI column)
+# Clean up invalid mappings for current repo (preserving others and optional AI column)
 # Usage: cleanup_mappings
 # Returns: 0 on success
 cleanup_mappings() {
@@ -158,14 +288,32 @@ cleanup_mappings() {
     tmpfile="$(mktemp)" || return 1
     trap 'rm -f "$tmpfile"' EXIT INT TERM
     
-    # Keep only valid mappings; preserve AI if present
-    while IFS=' ' read -r branch session ai; do
-        if git_branch_exists "$branch" && tmux_session_exists "$session"; then
-            suffix=""
-            [ -n "$ai" ] && suffix=" $ai"
-            echo "$branch $session$suffix"
+    repo_id=""
+    if repo_id_val="$(get_current_repo_id 2>/dev/null || true)" && [ -n "$repo_id_val" ]; then
+        repo_id="$repo_id_val"
+    fi
+    
+    # Re-emit entries: validate current repo entries; keep others untouched
+    while IFS=' ' read -r c1 c2 c3 c4; do
+        [ -z "$c1" ] && continue
+        if [ "${c1#repo:}" != "$c1" ]; then
+            map_repo="$c1"; branch="$c2"; session="$c3"; ai="$c4"
+        else
+            map_repo=""; branch="$c1"; session="$c2"; ai="$c3"
         fi
-    done < "$HYDRA_MAP" > "$tmpfile"
+        if [ -n "$repo_id" ] && [ "$map_repo" = "$repo_id" ]; then
+            if git_branch_exists "$branch" && tmux_session_exists "$session"; then
+                [ -n "$ai" ] && echo "$map_repo $branch $session $ai" >> "$tmpfile" || echo "$map_repo $branch $session" >> "$tmpfile"
+            fi
+        else
+            # Preserve non-current-repo entries as-is
+            if [ -n "$map_repo" ]; then
+                [ -n "$ai" ] && echo "$map_repo $branch $session $ai" >> "$tmpfile" || echo "$map_repo $branch $session" >> "$tmpfile"
+            else
+                [ -n "$ai" ] && echo "$branch $session $ai" >> "$tmpfile" || echo "$branch $session" >> "$tmpfile"
+            fi
+        fi
+    done < "$HYDRA_MAP"
     
     # Replace original file
     mv "$tmpfile" "$HYDRA_MAP"
@@ -257,7 +405,7 @@ release_session_lock() {
     fi
 }
 
-# Get AI tool for a branch (if stored)
+# Get AI tool for a branch (if stored) for current repo
 # Usage: get_ai_for_branch <branch>
 # Returns: AI tool on stdout, empty if not set
 get_ai_for_branch() {
@@ -265,10 +413,29 @@ get_ai_for_branch() {
     if [ -z "$branch" ] || [ -z "$HYDRA_MAP" ] || [ ! -f "$HYDRA_MAP" ]; then
         return 1
     fi
+    repo_id=""
+    if repo_id_val="$(get_current_repo_id 2>/dev/null || true)" && [ -n "$repo_id_val" ]; then
+        repo_id="$repo_id_val"
+    fi
+    # Prefer repo-scoped entries
+    while IFS=' ' read -r c1 c2 c3 c4; do
+        [ -z "$c1" ] && continue
+        if [ "${c1#repo:}" != "$c1" ]; then
+            map_repo="$c1"; map_branch="$c2"; map_ai="$c4"
+        else
+            map_repo=""; map_branch="$c1"; map_ai="$c3"
+        fi
+        if [ -n "$repo_id" ] && [ "$map_repo" = "$repo_id" ] && [ "$map_branch" = "$branch" ] && [ -n "$map_ai" ]; then
+            printf '%s\n' "$map_ai"; return 0
+        fi
+    done < "$HYDRA_MAP"
+    # Fallback to legacy
+    if [ -z "$repo_id" ]; then
+        return 1
+    fi
     while IFS=' ' read -r map_branch _map_session map_ai; do
         if [ "$map_branch" = "$branch" ] && [ -n "$map_ai" ]; then
-            echo "$map_ai"
-            return 0
+            printf '%s\n' "$map_ai"; return 0
         fi
     done < "$HYDRA_MAP"
     return 1

--- a/tests/test_project_scoping.sh
+++ b/tests/test_project_scoping.sh
@@ -1,0 +1,91 @@
+#!/bin/sh
+# Tests for project-scoped mappings to avoid cross-repo collisions
+
+test_count=0
+pass_count=0
+fail_count=0
+
+# Source state lib
+# shellcheck source=../lib/state.sh
+# shellcheck disable=SC1091
+. "$(dirname "$0")/../lib/state.sh"
+
+assert_equal() {
+  exp="$1"; got="$2"; msg="$3"
+  test_count=$((test_count+1))
+  if [ "$exp" = "$got" ]; then
+    pass_count=$((pass_count+1)); echo "✓ $msg"
+  else
+    fail_count=$((fail_count+1)); echo "✗ $msg (expected '$exp', got '$got')"
+  fi
+}
+
+assert_true() {
+  cond="$1"; msg="$2"
+  test_count=$((test_count+1))
+  if eval "$cond"; then
+    pass_count=$((pass_count+1)); echo "✓ $msg"
+  else
+    fail_count=$((fail_count+1)); echo "✗ $msg"
+  fi
+}
+
+setup() {
+  BASE_DIR="$(mktemp -d)" || exit 1
+  export HYDRA_HOME="$BASE_DIR/.hydra"
+  mkdir -p "$HYDRA_HOME"
+  export HYDRA_MAP="$HYDRA_HOME/map"
+  mkdir -p "$BASE_DIR/repoA" "$BASE_DIR/repoB"
+  # Initialize two repos
+  (cd "$BASE_DIR/repoA" && git init >/dev/null 2>&1 && git config user.email t@e && git config user.name t && echo a>f && git add f && git commit -m a >/dev/null 2>&1)
+  (cd "$BASE_DIR/repoB" && git init >/dev/null 2>&1 && git config user.email t@e && git config user.name t && echo b>g && git add g && git commit -m b >/dev/null 2>&1)
+}
+
+teardown() {
+  rm -rf "$BASE_DIR"
+}
+
+echo "Testing project-scoped mappings..."
+setup
+
+# In repoA, add mapping for branch 'main'
+cd "$BASE_DIR/repoA" || exit 1
+add_mapping main sessA
+assert_true "grep -q 'sessA' \"$HYDRA_MAP\"" "repoA mapping written"
+
+# In repoB, add mapping for same branch name but different session
+cd "$BASE_DIR/repoB" || exit 1
+add_mapping main sessB
+assert_true "grep -q 'sessB' \"$HYDRA_MAP\"" "repoB mapping written"
+
+# Verify lookups resolve to correct session per repo
+cd "$BASE_DIR/repoA" || exit 1
+gotA="$(get_session_for_branch main 2>/dev/null || true)"
+assert_equal "sessA" "$gotA" "get_session_for_branch is repo-scoped (A)"
+
+cd "$BASE_DIR/repoB" || exit 1
+gotB="$(get_session_for_branch main 2>/dev/null || true)"
+assert_equal "sessB" "$gotB" "get_session_for_branch is repo-scoped (B)"
+
+# Verify list_mappings_current_repo filters
+cd "$BASE_DIR/repoA" || exit 1
+cntA="$(list_mappings_current_repo | wc -l | tr -d ' ')"
+assert_equal "1" "$cntA" "list_mappings_current_repo returns only A entries"
+
+cd "$BASE_DIR/repoB" || exit 1
+cntB="$(list_mappings_current_repo | wc -l | tr -d ' ')"
+assert_equal "1" "$cntB" "list_mappings_current_repo returns only B entries"
+
+teardown
+
+echo ""
+echo "Test Results:"
+echo "  Total:  $test_count"
+echo "  Passed: $pass_count"
+echo "  Failed: $fail_count"
+
+if [ "$fail_count" -gt 0 ]; then
+  exit 1
+else
+  exit 0
+fi


### PR DESCRIPTION
Repo-scoped mapping:
      - New repo identifier: repo:<basename>-<hash8> derived from git repo root.
      - Map lines written as repo:<id> <branch> <session> [ai] when in a repo.
      - Backward compatible: legacy lines (<branch> <session> [ai]) still work and are treated as current repo for operations.
State functions updated:
      - add/remove/get for branch/session/ai now respect repo scope.
      - list_mappings_current_repo: emits only current repo entries (plus legacy).
      - validate_mappings and cleanup_mappings act on current repo entries and preserve others.
 CLI behavior adjusted:
      - list, switch, status, and kill --all now operate on current repo mappings via list_mappings_current_repo.
      - kill --all only affects current project.
Tests:
      - Added tests/test_project_scoping.sh covering two repos with same branch name mapping to different sessions.
      - All tests pass: make lint and make test.