### PR TITLE
feat(panel): add POSIX TUI control panel for managing heads

### DIFF
--- a/bin/hydra
+++ b/bin/hydra
@@ -81,6 +81,9 @@ fi
 # shellcheck source=../lib/yaml.sh
 # shellcheck disable=SC1091
 . "$HYDRA_LIB_DIR/yaml.sh"
+# shellcheck source=../lib/panel.sh
+# shellcheck disable=SC1091
+. "$HYDRA_LIB_DIR/panel.sh"
 
 # Export paths for downstream helpers (e.g., safe tmux run-shell bindings)
 export HYDRA_LIB_DIR
@@ -125,6 +128,9 @@ Commands:
   dashboard         View all sessions in a single dashboard
                     Options:
                       -p, --panes-per-session <N|all>  Collect multiple panes per session
+  panel             Interactive control panel for heads (TUI)
+                    Options:
+                      --print           Print summary and exit (non-interactive)
   cycle-layout      Cycle through tmux pane layouts
   completion        Generate shell completion scripts
   version           Show version information
@@ -516,6 +522,10 @@ main() {
         dashboard)
             shift
             cmd_dashboard "$@"
+            ;;
+        panel)
+            shift
+            cmd_panel "$@"
             ;;
         dashboard-exit)
             shift
@@ -1232,6 +1242,34 @@ cmd_cycle_layout() {
 cmd_completion() {
     shell="${1:-bash}"
     generate_completion "$shell"
+}
+
+# Control panel command
+cmd_panel() {
+    # Non-interactive print mode
+    print_only=0
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --print)
+                print_only=1
+                shift
+                ;;
+            -h|--help)
+                echo "Usage: hydra panel [--print]" ; return 0 ;;
+            *)
+                echo "Error: Unknown option '$1'" >&2
+                echo "Usage: hydra panel [--print]" >&2
+                return 1
+                ;;
+        esac
+    done
+
+    if [ "$print_only" -eq 1 ] || [ -n "${HYDRA_PANEL_NONINTERACTIVE:-}" ] || [ ! -t 0 ] || [ ! -t 1 ]; then
+        panel_print_summary
+        return $?
+    fi
+
+    run_control_panel
 }
 
 # Run main function with all arguments

--- a/lib/panel.sh
+++ b/lib/panel.sh
@@ -1,0 +1,102 @@
+#!/bin/sh
+# TUI Control Panel for Hydra (POSIX shell)
+
+# Render a summary table of current repo heads
+panel_print_summary() {
+    # Header
+    echo "Hydra Control Panel"
+    echo "===================="
+    # Repo info
+    if git rev-parse --git-dir >/dev/null 2>&1; then
+        repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+        [ -n "$repo_root" ] && echo "Repo: $repo_root"
+    fi
+    echo ""
+    # Table header
+    printf '%-4s %-30s %-24s %-8s %s\n' "#" "Branch" "Session" "Status" "AI"
+    printf '%s\n' "--------------------------------------------------------------------------------"
+
+    idx=1
+    # Prefer reading raw map file to be compatible across versions
+    list=""
+    if [ -n "${HYDRA_MAP:-}" ] && [ -f "$HYDRA_MAP" ]; then
+        list="$(cat "$HYDRA_MAP" 2>/dev/null || true)"
+    else
+        list="$(list_mappings 2>/dev/null || true)"
+    fi
+    if [ -z "$list" ]; then
+        echo "No heads for this repo. Use 'hydra spawn <branch>'."
+        return 0
+    fi
+    echo "$list" | while IFS=' ' read -r c1 c2 c3 c4; do
+        # Parse either repo-scoped lines (repo:ID branch session [ai]) or legacy (branch session [ai])
+        if [ "${c1#repo:}" != "$c1" ]; then
+            branch="$c2"; session="$c3"; ai="$c4"
+        else
+            branch="$c1"; session="$c2"; ai="$c3"
+        fi
+        [ -z "$branch" ] && continue
+        status="dead"
+        if tmux_session_exists "$session"; then
+            status="alive"
+        fi
+        printf '%-4s %-30s %-24s %-8s %s\n' "$idx" "$branch" "$session" "$status" "${ai:-}"
+        idx=$((idx + 1))
+    done
+    return 0
+}
+
+# Interactive control panel loop (line-based input for POSIX)
+run_control_panel() {
+    while : ; do
+        clear 2>/dev/null || printf '\033c' 2>/dev/null || true
+        panel_print_summary
+        echo ""
+        echo "Actions:"
+        echo "  <n>        switch/attach to head #n"
+        echo "  k <n>      kill head #n"
+        echo "  d          open dashboard"
+        echo "  r          refresh"
+        echo "  q          quit"
+        printf '> '
+        read -r cmd arg || break
+
+        case "${cmd:-}" in
+            q|quit|exit)
+                break ;;
+            r|refresh|"")
+                continue ;;
+            d)
+                # Open dashboard; do not attach if requested
+                if [ -n "${HYDRA_DASHBOARD_NO_ATTACH:-}" ]; then
+                    :
+                fi
+                "$HYDRA_BIN_CMD" dashboard 2>/dev/null || true
+                continue ;;
+            k)
+                if echo "${arg:-}" | grep -q '^[0-9][0-9]*$'; then
+                    entry="$(list_mappings_current_repo | sed -n "${arg}p")"
+                    branch="${entry%% *}"
+                    if [ -n "$branch" ]; then
+                        # Kill selected head (non-interactive)
+                        HYDRA_NONINTERACTIVE=1 "$HYDRA_BIN_CMD" kill "$branch" 2>/dev/null || true
+                    fi
+                fi
+                continue ;;
+            *)
+                # If numeric, switch to session
+                if echo "$cmd" | grep -q '^[0-9][0-9]*$'; then
+                    entry="$(list_mappings_current_repo | sed -n "${cmd}p")"
+                    # entry: branch session [ai]
+                    branch="${entry%% *}"
+                    session="$(printf '%s' "$entry" | awk '{print $2}')"
+                    if [ -n "$session" ]; then
+                        switch_to_session "$session" 2>/dev/null || true
+                    fi
+                    continue
+                fi
+                ;;
+        esac
+    done
+    return 0
+}

--- a/tests/test_panel.sh
+++ b/tests/test_panel.sh
@@ -1,0 +1,83 @@
+#!/bin/sh
+# Tests for Hydra TUI control panel (non-interactive mode)
+
+test_count=0
+pass_count=0
+fail_count=0
+
+HYDRA_BIN="$(cd "$(dirname "$0")/.." && pwd)/bin/hydra"
+
+assert_contains() {
+    haystack="$1"
+    needle="$2"
+    message="$3"
+    test_count=$((test_count + 1))
+    if echo "$haystack" | grep -q "$needle"; then
+        pass_count=$((pass_count + 1))
+        echo "✓ $message"
+    else
+        fail_count=$((fail_count + 1))
+        echo "✗ $message"
+        echo "  Expected to contain: '$needle'"
+    fi
+}
+
+setup() {
+    base_dir="$(mktemp -d)" || exit 1
+    repo_dir="$base_dir/repo"
+    mkdir -p "$repo_dir"
+    cd "$repo_dir" || exit 1
+    git init >/dev/null 2>&1
+    git config user.email test@example.com
+    git config user.name "Test User"
+    echo hi > one.txt
+    git add one.txt
+    git commit -m init >/dev/null 2>&1
+    export HYDRA_HOME="$base_dir/.hydra"
+    mkdir -p "$HYDRA_HOME"
+}
+
+teardown() {
+    # Kill any sessions created
+    tmux list-sessions -F '#{session_name}' 2>/dev/null | grep '^panel-' | while read -r s; do
+        tmux kill-session -t "$s" 2>/dev/null || true
+    done
+    rm -rf "$base_dir"
+}
+
+echo "Testing TUI control panel (non-interactive output)..."
+
+# Skip if tmux is not available
+if ! command -v tmux >/dev/null 2>&1; then
+    echo "⚠ tmux not available - skipping panel tests"
+    echo "Test Results:"
+    echo "  Total: 0"
+    echo "  Passed: 0"
+    echo "  Failed: 0"
+    exit 0
+fi
+
+setup
+
+"$HYDRA_BIN" spawn panel-a >/dev/null 2>&1 || true
+"$HYDRA_BIN" spawn panel-b >/dev/null 2>&1 || true
+
+out="$(HYDRA_PANEL_NONINTERACTIVE=1 "$HYDRA_BIN" panel 2>/dev/null || true)"
+assert_contains "$out" "Hydra Control Panel" "prints header"
+assert_contains "$out" "panel-a" "lists first head"
+assert_contains "$out" "panel-b" "lists second head"
+
+teardown
+
+echo ""
+echo "Test Results:"
+echo "  Total:  $test_count"
+echo "  Passed: $pass_count"
+echo "  Failed: $fail_count"
+
+if [ "$fail_count" -gt 0 ]; then
+    exit 1
+else
+    exit 0
+fi
+


### PR DESCRIPTION
This PR adds a simple POSIX-compliant TUI “control panel” for Hydra.

Summary
- New command: `hydra panel` with an interactive, line-based interface.
- Actions:
  - `<n>`: switch/attach to head #n
  - `k <n>`: kill head #n (non-interactive)
  - `d`: open dashboard (best-effort)
  - `r`: refresh, `q`: quit
- Non-interactive mode:
  - `hydra panel --print` or `HYDRA_PANEL_NONINTERACTIVE=1` prints a formatted summary and exits.
- Implementation details:
  - Pure POSIX shell; no external TUI libs.
  - Works inside or outside tmux, uses existing tmux helpers.
  - Compatible with current map format; robust to potential repo-scoped entries.

Tests
- `tests/test_panel.sh` verifies the `--print` output includes active heads.
- Full test suite (`make test`) passes locally.

Rationale
Provides a quick, ergonomic overview and basic management controls without leaving the terminal or requiring extra dependencies, complementing the existing `dashboard` feature.

