### PR TITLE
chore(version): set HYDRA_VERSION=1.3.0 on release/v1.3.0

### DIFF
--- a/bin/hydra
+++ b/bin/hydra
@@ -11,7 +11,7 @@ if [ -z "${HOME:-}" ] || [ ! -d "${HOME:-}" ]; then
 fi
 HYDRA_HOME="${HYDRA_HOME:-$HOME/.hydra}"
 HYDRA_MAP="$HYDRA_HOME/map"
-HYDRA_VERSION="1.2.0"
+HYDRA_VERSION="1.3.0"
 
 # Source helper libraries
 # Enhanced library detection with multiple fallback paths


### PR DESCRIPTION
Updates `HYDRA_VERSION` to `1.3.0` on the `release/v1.3.0` branch so `hydra version` and `hydra status` report the correct version string.

- Simple bump from `1.2.0` to `1.3.0`.
- Lint + tests pass.

Closes #48
