### PR TITLE
Set up Cursor Cloud dev environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+Hydra is a single-binary POSIX shell CLI (`bin/hydra`) that orchestrates one tmux
+session + one git worktree per branch ("head"). Library code lives in `lib/*.sh`;
+tests are plain POSIX shell scripts in `tests/*.sh`. There is no compiled build step.
+
+### Toolchain
+- Required to run/lint/test: `git`, `tmux` (>= 3.0), `dash`, `shellcheck`, GNU `make`.
+  `/bin/sh` is `dash` on this VM, which is exactly what the POSIX-compliance checks
+  assume, so tests run under dash by default.
+- Optional (improve UX, not required for tests): `fzf` (interactive `switch`/`tui`),
+  `gh` (GitHub issue/PR features), and an AI CLI such as `claude`/`aider`/`gemini`.
+
+### Lint / Test / Run (standard commands, see `Makefile` and `README.md`)
+- Lint: `make lint` — runs ShellCheck (`--shell=sh --severity=style`) plus `dash -n`
+  syntax checks on every shell file.
+- Test: `make test` — runs each `tests/*.sh` with `sh`. Passing runs still print
+  `Error: ...` lines: those are expected error-path assertions, not failures. Judge
+  success by the exit code and the `Failed: 0` summaries.
+
+### Running the app from source (non-obvious caveats)
+- Run it directly as `bin/hydra <command>`; it auto-detects `lib/` relative to the
+  binary, so no install is needed. `HYDRA_ROOT=/workspace` forces library discovery
+  if you invoke it from elsewhere.
+- `hydra spawn` creates a real tmux session and a git worktree under `/tmp/hydra-<branch>`.
+  To avoid creating worktrees/branches inside this repo, run spawn/kill demos inside a
+  throwaway `git init` repo in a temp dir.
+- For non-interactive automation set `HYDRA_NONINTERACTIVE=1` (skips confirm prompts)
+  and `HYDRA_SKIP_AI=1` (does not try to launch an AI CLI on spawn). Runtime state
+  (the head->session map) lives in `~/.hydra/map`.
+- Known pre-existing issue (not an environment problem): `hydra status` can print
+  `Illegal number ...` from shell arithmetic on a duration field; `list`, `list --json`,
+  `spawn`, and `kill` all work correctly.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Cloud Agent development environment for Hydra (a POSIX shell tmux + git-worktree orchestrator) and documents non-obvious run/test caveats for future agents.

This repo has no code-level changes — it was already working. The only additions are environment setup and docs.

## What was done
- Installed the missing toolchain dependency `shellcheck` (required by `make lint`) plus optional `fzf` (interactive `switch`/`tui`). `git`, `tmux 3.5a`, `dash`, `make`, and `gh` were already present, and `/bin/sh` is `dash` (matching the POSIX-compliance checks).
- Configured a minimal, idempotent startup update script that ensures `shellcheck`/`fzf` are present.
- Added `AGENTS.md` with a `## Cursor Cloud specific instructions` section covering the toolchain, lint/test commands, and non-obvious run caveats (running from source, spawn creating tmux sessions + `/tmp/hydra-*` worktrees, `HYDRA_NONINTERACTIVE`/`HYDRA_SKIP_AI`, and a pre-existing `hydra status` arithmetic quirk).

## Verification
- `make lint` — ShellCheck + dash syntax: **All checks passed**.
- `make test` — full `tests/*.sh` suite: **all suites passed, 0 failures**.
- App hello-world: `hydra spawn feature-hello` created a tmux session + git worktree, `hydra list` / `list --json` showed the head, and `hydra kill` cleaned up the session and worktree.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0a5943c6-0e9e-4a79-be66-e29f4d37a8ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0a5943c6-0e9e-4a79-be66-e29f4d37a8ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

