### PR TITLE
Hydra 1.5.1: shell baseline hardening

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,7 @@ CLAUDE.md
 *.tmp
 
 # GitHub Actions
-.github/workflows/*.logROADMAP.md
+.github/workflows/*.log
+
+# Hydra runtime state (live state lives under $HYDRA_HOME, default ~/.hydra)
+.hydra/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ tests are plain POSIX shell scripts in `tests/*.sh`. There is no compiled build 
 ### Lint / Test / Run (standard commands, see `Makefile` and `README.md`)
 - Lint: `make lint` — runs ShellCheck (`--shell=sh --severity=style`) plus `dash -n`
   syntax checks on every shell file.
-- Test: `make test` — runs each `tests/*.sh` with `sh`. Passing runs still print
+- Test: `make test` — runs each `tests/test_*.sh` with `sh`. Passing runs still print
   `Error: ...` lines: those are expected error-path assertions, not failures. Judge
   success by the exit code and the `Failed: 0` summaries.
 
@@ -30,6 +30,3 @@ tests are plain POSIX shell scripts in `tests/*.sh`. There is no compiled build 
 - For non-interactive automation set `HYDRA_NONINTERACTIVE=1` (skips confirm prompts)
   and `HYDRA_SKIP_AI=1` (does not try to launch an AI CLI on spawn). Runtime state
   (the head->session map) lives in `~/.hydra/map`.
-- Known pre-existing issue (not an environment problem): `hydra status` can print
-  `Illegal number ...` from shell arithmetic on a duration field; `list`, `list --json`,
-  `spawn`, and `kill` all work correctly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.1] - 2026-08-25
+
+### Added
+- Public contract snapshot in `docs/CONTRACTS.md` (map fields, JSON, locks, TUI rows, send-keys targets)
+- Supported-platform statement (Linux and macOS, POSIX `sh`, `tmux >= 3.0`)
+- `make bench` / `scripts/bench.sh` for list, status, doctor, and TUI refresh timings at 5 and 20 heads
+- `tests/bin/tmux` stub for deterministic send-keys and pane-target tests
+- Broadcast `--pane` and `--force` for explicit pane targeting
+
+### Changed
+- State map writers share the `state_map` mkdir lock and fail closed if it cannot be acquired
+- Replacement files are created next to their destination before `mv`
+- Queue filenames sort by priority (high first) then request time, with a monotonic seq for FIFO
+- `json_escape` emits `\n` / `\r` / `\b` / `\f` and `\u00XX` for remaining C0 controls
+- Startup and agent launch always send keys to `session:0.0`
+- TUI list readers consume the eight-field tab row contract
+- TUI activity prefers `window_activity` from a batched pane snapshot; capture-pane hashing is fallback
+- `hydra list` / `status` use a tmux session snapshot instead of per-head `has-session` where loaded
+- Shell completion covers every command dispatched by `bin/hydra`
+
+### Fixed
+- `hydra status` no longer treats deps/PR as part of the duration timestamp (`Illegal number`)
+- Kill preflights dirty/untracked worktrees before tearing down tmux or mappings
+- Message inboxes are removed from kill and dead-mapping cleanup
+- Doctor/cleanup stale-lock detection matches empty `*.lock` directories
+- `hydra regenerate` preserves group, deps, PR, and timestamp
+- Malformed `.gitignore` entry; runtime `.hydra/` is no longer tracked
+
 ## [1.5.0] - 2026-08-24
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -168,9 +168,11 @@ var="${VAR:-default}"
 
 #### Temporary Files
 ```sh
-# Create safely
-tmpfile="$(mktemp)" || exit 1
-trap 'rm -f "$tmpfile"' EXIT INT TERM
+# Create the temp file on the same filesystem as the destination, then rename.
+# Bare mktemp usually lands in /tmp; mv across devices is not atomic.
+tmpfile="$(mktemp_adjacent "$dest")" || exit 1
+# write to "$tmpfile"...
+atomic_replace "$dest" "$tmpfile" || { rm -f "$tmpfile"; exit 1; }
 ```
 
 ### Resources

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Makefile for Hydra
 # POSIX-compliant build and lint tasks
 
-.PHONY: all lint test clean install dev-setup help
+.PHONY: all lint test clean install dev-setup bench help
 
 # Default target
 all: lint
@@ -20,17 +20,21 @@ lint:
 	done
 	@echo "All checks passed!"
 
-# Run tests
+# Run tests (skip helpers.sh — it is a library, not a suite)
 test:
 	@echo "Running tests..."
-	@if [ -d tests ] && [ -n "$$(ls -A tests/*.sh 2>/dev/null)" ]; then \
-		for test in tests/*.sh; do \
+	@if [ -d tests ] && [ -n "$$(ls -A tests/test_*.sh 2>/dev/null)" ]; then \
+		for test in tests/test_*.sh; do \
 			echo "Running $$test..."; \
 			sh "$$test" || exit 1; \
 		done; \
 	else \
 		echo "No tests found in tests/"; \
 	fi
+
+# Record shell baseline timings (not a CI gate; no speedup claims)
+bench:
+	@sh scripts/bench.sh
 
 # Clean temporary files
 clean:
@@ -64,6 +68,7 @@ help:
 	@echo "Hydra Makefile targets:"
 	@echo "  make lint      - Run ShellCheck and dash syntax validation"
 	@echo "  make test      - Run all tests"
+	@echo "  make bench     - Record list/status/doctor/TUI timings at 5 and 20 heads"
 	@echo "  make clean     - Remove temporary files"
 	@echo "  make install   - Install hydra to /usr/local/bin"
 	@echo "  make dev-setup - Set up development environment (git hooks)"

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@
 ## Quick Start
 
 - Requirements: `git`, `tmux` (≥ 3.0). Optional: `fzf`, GitHub CLI, an AI CLI (`claude`, `aider`, `gemini`, etc.).
+- Supported platforms: Linux and macOS; POSIX `sh` (dash on Debian/Ubuntu); `tmux >= 3.0` and `git`. CI runs Ubuntu and macOS. Windows is not supported.
+- Public CLI, map, JSON, lock, and TUI-row contracts: [docs/CONTRACTS.md](docs/CONTRACTS.md).
 - Install:
   - `git clone https://github.com/Someblueman/hydra && cd hydra && sudo ./install.sh`
   - or `sudo make install`

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,44 +1,51 @@
-# Hydra v1.5.0 Release Notes
+# Hydra v1.5.1 Release Notes
 
-**Release date:** 2026-08-24
+**Release date:** 2026-08-25
 
 ## Highlights
 
-Hydra 1.5.0 is a major usability and maintainability release: a refreshed TUI, comprehensive bugfixes from the 1.4.3 audit, and a full internal refactor that splits the largest source files into focused modules.
+Hydra 1.5.1 hardens the shipped POSIX shell CLI so it is a trustworthy baseline:
+locking and atomic file replace, kill/regenerate/queue/JSON correctness, explicit
+tmux pane targets, and a documented 1.5 public contract. No state migration is
+required.
 
-## TUI Refresh
+## Correctness
 
-- Two-panel layout with detail sidebar on terminals ≥100 columns wide
-- **Enter** now switches sessions (`s` still works)
-- **A** select all, **D** open dashboard, **f** preview follow mode
-- Interactive spawn wizard with AI tool picker
-- Search across branch, session, group, and AI tool
-- Configurable refresh via `HYDRA_TUI_REFRESH_MS`
+- Map writers share one lock and no longer write if acquisition fails
+- Temp files for map/tags rewrites stay on the same filesystem as the destination
+- `hydra status` reads all seven map fields and validates duration timestamps
+- `hydra kill` checks dirty worktrees before killing tmux or dropping the mapping
+- Message inboxes are deleted on kill and dead-mapping cleanup
+- Doctor/cleanup stale locks match the `mkdir` `*.lock` directory format
+- `hydra regenerate` keeps group, dependency, PR, and timestamp metadata
+- Spawn queue processes high priority first, FIFO within one priority
+- JSON strings escape every C0 control character
 
-## Bugfixes
+## tmux and TUI
 
-- Doctor/cleanup/regenerate correctly find `../hydra-<branch>` worktrees (including slash branches)
-- Spawn rollback on invalid AI tool; queue fixes for mixed agents and failed retries
-- Session limits count live tmux sessions only
-- TUI bulk group assignment works via `set_group`
+- Startup and agent launch target `session:0.0`
+- `hydra broadcast` prefers a non-agent shell pane; refuses agent-only sessions unless `--force` or `--pane`
+- TUI rows are eight tab-separated fields end to end
+- List/status/TUI refresh batch tmux session and pane observations (`window_activity` first)
 
-## Architecture
+## Docs and tooling
 
-- `bin/hydra` is now a thin dispatcher
-- Commands live in `lib/cmd_*.sh`
-- TUI split into `lib/tui_*.sh`
-- State cache in `lib/state_cache.sh`
-- Shared maintenance checks in `lib/maintenance.sh`
+- [docs/CONTRACTS.md](docs/CONTRACTS.md) records the 1.5 public surface
+- README states supported platforms
+- `make bench` records shell timings (measurements only)
+- Completions include `group`, `send`, `recv`, `tail`, `broadcast`, `wait-idle`, `queue`
 
 ## Upgrade
 
 ```sh
 sudo ./install.sh   # or: sudo make install
-hydra version       # should show 1.5.0
+hydra version       # should show 1.5.1
 ```
 
-No migration steps required for `~/.hydra` state files.
+No migration steps required for `~/.hydra` state files. Non-root `PREFIX`
+install remains a 1.5.2 item.
 
 ## Test Coverage
 
-Run `make test` — 25+ test suites including expanded paths and TUI tests.
+Run `make lint` and `make test`. Passing runs may still print `Error: ...`
+lines from expected error-path assertions.

--- a/bin/hydra
+++ b/bin/hydra
@@ -11,7 +11,7 @@ if [ -z "${HOME:-}" ] || [ ! -d "${HOME:-}" ]; then
 fi
 HYDRA_HOME="${HYDRA_HOME:-$HOME/.hydra}"
 HYDRA_MAP="$HYDRA_HOME/map"
-HYDRA_VERSION="1.5.0"
+HYDRA_VERSION="1.5.1"
 
 # Source helper libraries
 # Enhanced library detection with multiple fallback paths
@@ -95,6 +95,7 @@ _load_libs_for_cmd() {
             ;;
         list|switch|status|cycle-layout)
             _load_lib output
+            _load_lib locks
             _load_lib state
             _load_lib tmux
             _load_lib layout
@@ -108,6 +109,7 @@ _load_libs_for_cmd() {
             _load_lib git
             _load_lib tmux
             _load_lib state
+            _load_lib messages
             _load_lib kill
             _load_lib limits
             _load_lib spawn
@@ -153,6 +155,7 @@ _load_libs_for_cmd() {
             _load_lib git
             _load_lib locks
             _load_lib output
+            _load_lib messages
             _load_lib spawn
             _load_lib cmd_spawn
             _load_lib cmd_maintenance
@@ -297,6 +300,8 @@ Commands:
   broadcast         Send a command to multiple sessions
                     Options:
                       -g, --group <name>       Target specific group
+                      --pane <target>          Explicit tmux pane (window.pane or session:window.pane)
+                      --force                  Send to :0.0 even if that pane is the agent
   wait-idle         Wait for sessions to become idle
                     Options:
                       -g, --group <name>       Wait for specific group

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -1,0 +1,80 @@
+# Hydra 1.5 public contracts
+
+This document records which 1.5.0 behaviors remain public through 1.5.1.
+Internal function names, the in-process state cache, and TUI render details
+are not contracts.
+
+## CLI
+
+- Commands dispatched by `bin/hydra` (including `group`, `send`, `recv`, `tail`,
+  `broadcast`, `wait-idle`, `queue`, and `dashboard-exit`) are part of the
+  user-facing command set. Shell completion covers that set.
+- `hydra version` / `--version` print `Hydra version <semver>`.
+- Mutating commands fail closed on lock acquisition failure: they print an
+  error and do not write. They do not fall back to an unlocked write.
+- `hydra kill` checks worktree dirtiness **before** killing tmux or removing
+  the mapping. `--force` on `kill --all` only skips the confirmation prompt.
+
+## State map
+
+Runtime file: `$HYDRA_HOME/map` (default `~/.hydra/map`).
+
+Seven space-separated fields per line:
+
+```text
+branch session ai_tool group timestamp deps pr_number
+```
+
+Optional fields use `-` as a placeholder. Timestamp is a Unix epoch in
+seconds. `hydra regenerate` preserves every field except the tmux session
+name.
+
+## Locks
+
+Locks are empty directories `$HYDRA_HOME/locks/<name>.lock` created with
+`mkdir`. There is no `pid` file in 1.5.1. Stale locks are directories whose
+mtime is older than one minute (`find -mmin +1`). Doctor and cleanup use that
+same format.
+
+## Atomic replacement
+
+Writers create a temp file in the destination directory (`mktemp_adjacent`)
+and `mv` it into place so the rename stays on one filesystem.
+
+## JSON
+
+`list --json`, `status --json`, `recv --json`, `queue --json`, and
+`group status --json` emit JSON objects/arrays.
+
+`json_escape` operates on POSIX C strings (NUL cannot appear). It escapes
+`"`, `\`, `\b`, `\t`, `\n`, `\f`, `\r`, and other C0 controls as `\u00XX`.
+Callers must never emit raw control characters inside JSON strings.
+
+## TUI row schema
+
+`tui_build_list` writes one row per head, eight TAB-separated fields:
+
+```text
+branch  session  ai  status  tag  activity  group  pr
+```
+
+`status` is `ALIVE` or `DEAD`. `activity` is `BUSY`, `IDLE`, or `-`.
+
+## tmux send-keys
+
+Startup commands and agent launch target `session:0.0`, not the active pane.
+
+`hydra broadcast` sends to a non-agent shell pane when one exists. If the only
+pane is the agent (typical `default` layout), broadcast refuses unless
+`--force` (then `:0.0`) or `--pane` is given.
+
+## Environment
+
+Documented in the README: `HYDRA_HOME`, `HYDRA_ROOT`, `HYDRA_AI_COMMAND`,
+`HYDRA_SKIP_AI`, `HYDRA_NONINTERACTIVE`, and the other `HYDRA_*` variables
+listed there.
+
+## Not covered
+
+State v2, instance IDs, events, native helpers, and non-root `PREFIX` install
+are later releases. Pre-2.0 internal library layout may change.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -134,31 +134,31 @@ artifacts, native-aware installation, or native CI.
 
 ### 4.2 Known hardening work carried into 1.5.1
 
-- [ ] Wire message cleanup into kill and cleanup paths.
-- [ ] Align maintenance stale-lock detection with the actual `mkdir` lock format.
-- [ ] Make every state writer use the same lock; never mutate after lock acquisition
+- [x] Wire message cleanup into kill and cleanup paths.
+- [x] Align maintenance stale-lock detection with the actual `mkdir` lock format.
+- [x] Make every state writer use the same lock; never mutate after lock acquisition
       fails.
-- [ ] Create replacement files on the same filesystem as their destination before
+- [x] Create replacement files on the same filesystem as their destination before
       atomic rename.
-- [ ] Update shell completion for all commands shipped through 1.5.0.
-- [ ] Fix the known `hydra status` invalid-duration arithmetic path.
-- [ ] Preflight dirty-worktree handling before killing tmux or removing state so a
+- [x] Update shell completion for all commands shipped through 1.5.0.
+- [x] Fix the known `hydra status` invalid-duration arithmetic path.
+- [x] Preflight dirty-worktree handling before killing tmux or removing state so a
       failed worktree deletion cannot leave an untracked orphan.
-- [ ] Preserve group, dependency, pull-request, timestamp, and future metadata when
+- [x] Preserve group, dependency, pull-request, timestamp, and future metadata when
       regenerating a session.
-- [ ] Make queue ordering honor priority before request time, with stable FIFO order
+- [x] Make queue ordering honor priority before request time, with stable FIFO order
       within one priority.
-- [ ] Escape every required JSON control character and add byte-oriented fixtures.
-- [ ] Give broadcast and startup delivery an explicit pane/transport target; never
+- [x] Escape every required JSON control character and add byte-oriented fixtures.
+- [x] Give broadcast and startup delivery an explicit pane/transport target; never
       type into an agent prompt merely because that pane is active.
-- [ ] Define and correct the shell TUI row contract: the producer currently emits
+- [x] Define and correct the shell TUI row contract: the producer currently emits
       eight tab-separated fields while readers document or consume fewer fields and
       use a literal `\t` as `IFS` rather than an actual tab.
-- [ ] Add focused tests for maintenance, state-cache invalidation, messages, and TUI
+- [x] Add focused tests for maintenance, state-cache invalidation, messages, and TUI
       row parsing before using them as native parity oracles.
-- [ ] Fix the malformed `.gitignore` entry and stop tracking runtime state in the
+- [x] Fix the malformed `.gitignore` entry and stop tracking runtime state in the
       repository.
-- [ ] Document exactly which 1.5.0 behaviors are considered public contracts.
+- [x] Document exactly which 1.5.0 behaviors are considered public contracts.
 
 ### 4.3 Current onboarding friction
 
@@ -559,18 +559,18 @@ commands, hooks, and SSH. Each is a code-execution boundary.
 
 #### Scope
 
-- [ ] Complete the hardening list in section 4.2.
-- [ ] Add regression tests for status, lock failure, same-filesystem replacement,
+- [x] Complete the hardening list in section 4.2.
+- [x] Add regression tests for status, lock failure, same-filesystem replacement,
       message cleanup, kill ordering, regenerate preservation, queue priority, JSON
       control bytes, explicit pane targeting, and TUI framing.
-- [ ] Document the current state fields and behavior before migration.
-- [ ] Replace repeated per-head tmux probes with formatted batch queries where this
+- [x] Document the current state fields and behavior before migration.
+- [x] Replace repeated per-head tmux probes with formatted batch queries where this
       preserves the documented behavior.
-- [ ] Use `window_activity`, `pane_current_command`, and `pane_dead` as the primary
+- [x] Use `window_activity`, `pane_current_command`, and `pane_dead` as the primary
       shell activity/process observations; keep pane hashing only as a fallback.
-- [ ] Record baseline performance for list, TUI refresh, doctor, and pane capture at
+- [x] Record baseline performance for list, TUI refresh, doctor, and pane capture at
       5 and 20 heads.
-- [ ] Add a supported-platform statement for the shell-only release.
+- [x] Add a supported-platform statement for the shell-only release.
 
 #### Release gates
 
@@ -1220,10 +1220,10 @@ These are bounded design gates, not permission for open-ended architecture work.
 
 ### Now: finish the shell baseline
 
-1. Close the 1.5.1 defects and add focused regression tests.
+1. Close the 1.5.1 defects and add focused regression tests. **Done in 1.5.1.**
 2. Batch remaining tmux probes and establish the `window_activity`-based observation
-   contract.
-3. Capture benchmark fixtures for the current shell paths.
+   contract. **Done in 1.5.1.**
+3. Capture benchmark fixtures for the current shell paths. **`make bench` in 1.5.1.**
 
 ### Next: remove first-run friction
 

--- a/lib/cmd_session.sh
+++ b/lib/cmd_session.sh
@@ -110,16 +110,8 @@ cmd_list() {
     # Cache current session once before the loop (perf: issue #36)
     current_session="$(tmux display-message -p '#{session_name}' 2>/dev/null || true)"
 
-    # Cache all tmux sessions once to avoid repeated subprocess calls (perf: v1.3.3)
-    _cached_tmux_sessions="$(tmux list-sessions -F '#{session_name}' 2>/dev/null || true)"
-
-    # Helper to check session existence against cache
-    _session_exists_cached() {
-        echo "$_cached_tmux_sessions" | grep -qx "$1" 2>/dev/null
-    }
-
-    # Cache current timestamp once to avoid repeated date calls (perf: v1.3.3)
-    _cached_now="$(date +%s)"
+    # Batch tmux observation for this command
+    tmux_load_snapshot
 
     if [ -n "$json_output" ]; then
         # JSON output mode
@@ -139,15 +131,15 @@ cmd_list() {
 
             total=$((total + 1))
 
-            # Calculate duration (use cached timestamp for perf)
+            # Calculate duration (validated numeric subtraction)
             duration_secs=0
             if [ -n "$timestamp" ] && [ "$timestamp" != "-" ]; then
-                duration_secs="$((_cached_now - timestamp))"
+                duration_secs="$(get_duration_since "$timestamp")"
             fi
             duration_human="$(format_duration "$duration_secs")"
 
-            # Determine status (use cached check for perf)
-            if _session_exists_cached "$session"; then
+            # Determine status (use snapshot loaded above)
+            if tmux_session_exists "$session"; then
                 status="active"
                 active=$((active + 1))
             else
@@ -240,10 +232,10 @@ cmd_list() {
                 fi
             fi
 
-            # Calculate duration if timestamp exists (use cached timestamp for perf)
+            # Calculate duration if timestamp exists
             duration_str=""
             if [ -n "$timestamp" ] && [ "$timestamp" != "-" ]; then
-                duration_secs="$((_cached_now - timestamp))"
+                duration_secs="$(get_duration_since "$timestamp")"
                 duration_str="$(format_duration "$duration_secs")"
             fi
 
@@ -291,8 +283,8 @@ cmd_list() {
                 fi
             fi
 
-            # Check if session still exists (use cached check for perf)
-            if _session_exists_cached "$session"; then
+            # Check if session still exists (use snapshot loaded above)
+            if tmux_session_exists "$session"; then
                 # Check if it's the current session
                 if [ "$session" = "$current_session" ]; then
                     echo "* $branch -> $session $status_line (current)"
@@ -315,16 +307,13 @@ cmd_switch() {
 
     # If inside tmux, use tmux's interactive switcher
     if [ -n "${TMUX:-}" ]; then
-        # Cache all tmux sessions once to avoid repeated subprocess calls (perf)
-        _cached_tmux_sessions="$(tmux list-sessions -F '#{session_name}' 2>/dev/null || true)"
-        _session_exists_cached() {
-            echo "$_cached_tmux_sessions" | grep -qx "$1" 2>/dev/null
-        }
+        # Batch tmux observation for this command
+        tmux_load_snapshot
 
         # Build session list for fzf or simple menu (tab-separated: branch, session)
         sessions=""
         while IFS=' ' read -r branch session _rest; do
-            if _session_exists_cached "$session"; then
+            if tmux_session_exists "$session"; then
                 sessions="${sessions}${branch}	${session}
 "
             fi
@@ -566,7 +555,8 @@ cmd_status() {
         dead=0
 
         if [ -f "$HYDRA_MAP" ] && [ -s "$HYDRA_MAP" ]; then
-            while IFS=' ' read -r branch session ai group timestamp; do
+            tmux_load_snapshot
+            while IFS=' ' read -r branch session ai group timestamp deps pr; do
                 # Calculate duration
                 duration_secs=0
                 if [ -n "$timestamp" ] && [ "$timestamp" != "-" ]; then
@@ -653,7 +643,8 @@ cmd_status() {
         active=0
         dead=0
 
-        while IFS=' ' read -r branch session ai group timestamp; do
+        tmux_load_snapshot
+        while IFS=' ' read -r branch session ai group timestamp deps pr; do
             # Calculate duration if timestamp exists
             duration_str=""
             if [ -n "$timestamp" ] && [ "$timestamp" != "-" ]; then

--- a/lib/cmd_session_ops.sh
+++ b/lib/cmd_session_ops.sh
@@ -82,6 +82,8 @@ cmd_broadcast() {
     # Send a command to all sessions or a group
     broadcast_group=""
     command_text=""
+    force_pane=""
+    explicit_pane=""
 
     while [ $# -gt 0 ]; do
         case "$1" in
@@ -90,9 +92,18 @@ cmd_broadcast() {
                 broadcast_group="$1"
                 shift
                 ;;
+            --force)
+                force_pane=1
+                shift
+                ;;
+            --pane)
+                shift
+                explicit_pane="$1"
+                shift
+                ;;
             -*)
                 echo "Error: Unknown option '$1'" >&2
-                echo "Usage: hydra broadcast [-g|--group <name>] <command>" >&2
+                echo "Usage: hydra broadcast [-g|--group <name>] [--pane <target>] [--force] <command>" >&2
                 return 1
                 ;;
             *)
@@ -105,7 +116,7 @@ cmd_broadcast() {
 
     if [ -z "$command_text" ]; then
         echo "Error: Command required" >&2
-        echo "Usage: hydra broadcast [-g|--group <name>] <command>" >&2
+        echo "Usage: hydra broadcast [-g|--group <name>] [--pane <target>] [--force] <command>" >&2
         return 1
     fi
 
@@ -138,8 +149,25 @@ cmd_broadcast() {
 
     echo "$mappings" | while IFS=' ' read -r branch session _ai _group; do
         if _session_exists_cached "$session"; then
-            echo "  Sending to $branch ($session)..."
-            tmux send-keys -t "$session" "$command_text" Enter 2>/dev/null || true
+            _target=""
+            if [ -n "$explicit_pane" ]; then
+                case "$explicit_pane" in
+                    *:*) _target="$explicit_pane" ;;
+                    *) _target="${session}:${explicit_pane}" ;;
+                esac
+            else
+                _target="$(find_broadcast_pane "$session" "$_ai" 2>/dev/null || true)"
+                if [ -z "$_target" ]; then
+                    if [ -n "$force_pane" ]; then
+                        _target="${session}:0.0"
+                    else
+                        echo "  Skipping $branch ($session): no shell pane (agent on :0.0; use --force or --pane)" >&2
+                        continue
+                    fi
+                fi
+            fi
+            echo "  Sending to $branch ($session) via $_target..."
+            tmux send-keys -t "$_target" "$command_text" Enter 2>/dev/null || true
             # Increment count in file
             _cnt="$(cat "$tmpcount")"
             printf "%d" "$((_cnt + 1))" > "$tmpcount"

--- a/lib/cmd_spawn.sh
+++ b/lib/cmd_spawn.sh
@@ -424,7 +424,12 @@ cmd_regenerate() {
         if create_session "$session" "$dir"; then
             # Preserve any stored AI tool for this branch
             stored_ai="$(get_ai_for_branch "$branch" 2>/dev/null || true)"
-            add_mapping "$branch" "$session" "$stored_ai"
+            stored_group="$(get_group_for_branch "$branch" 2>/dev/null || true)"
+            stored_ts="$(get_timestamp_for_branch "$branch" 2>/dev/null || true)"
+            stored_deps="$(get_deps_for_branch "$branch" 2>/dev/null || true)"
+            stored_pr="$(get_pr_for_branch "$branch" 2>/dev/null || true)"
+            add_mapping "$branch" "$session" "$stored_ai" "$stored_group" \
+                "${stored_ts:-}" "$stored_deps" "$stored_pr"
             regenerated=$((regenerated + 1))
             # Release any reserved session name lock
             release_session_lock "$session" 2>/dev/null || true

--- a/lib/completion.sh
+++ b/lib/completion.sh
@@ -16,7 +16,7 @@ _hydra_completion() {
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
 
-    commands="spawn list switch kill regenerate status doctor dashboard cycle-layout tui cleanup pr template completion version help"
+    commands="spawn list switch kill regenerate status doctor dashboard dashboard-exit cycle-layout tui cleanup pr template completion version help group send recv tail broadcast wait-idle queue"
     opts="-h --help -v --version"
     
     case "${prev}" in
@@ -237,6 +237,7 @@ _hydra_commands() {
         'status:Show health status of all heads'
         'doctor:Check system performance'
         'dashboard:View all sessions in a single dashboard'
+        'dashboard-exit:Exit the dashboard session'
         'cycle-layout:Cycle through tmux pane layouts'
         'tui:Interactive terminal UI for session management'
         'cleanup:Remove orphaned worktrees and mappings'
@@ -245,6 +246,13 @@ _hydra_commands() {
         'completion:Generate shell completion scripts'
         'version:Show version information'
         'help:Show help message'
+        'group:Show or set session groups'
+        'send:Queue a message to a session inbox'
+        'recv:Read messages for the current session'
+        'tail:View output from a session'
+        'broadcast:Send a command to sessions'
+        'wait-idle:Wait for sessions to become idle'
+        'queue:Inspect or process the spawn queue'
     )
     _describe 'command' commands
 }
@@ -292,6 +300,7 @@ complete -c hydra -f -n '__fish_use_subcommand' -a 'regenerate' -d 'Restore tmux
 complete -c hydra -f -n '__fish_use_subcommand' -a 'status' -d 'Show health status of all heads'
 complete -c hydra -f -n '__fish_use_subcommand' -a 'doctor' -d 'Check system performance'
 complete -c hydra -f -n '__fish_use_subcommand' -a 'dashboard' -d 'View all sessions in a single dashboard'
+complete -c hydra -f -n '__fish_use_subcommand' -a 'dashboard-exit' -d 'Exit the dashboard session'
 complete -c hydra -f -n '__fish_use_subcommand' -a 'cycle-layout' -d 'Cycle through tmux pane layouts'
 complete -c hydra -f -n '__fish_use_subcommand' -a 'tui' -d 'Interactive terminal UI for session management'
 complete -c hydra -f -n '__fish_use_subcommand' -a 'cleanup' -d 'Remove orphaned worktrees and mappings'
@@ -300,6 +309,13 @@ complete -c hydra -f -n '__fish_use_subcommand' -a 'template' -d 'Manage session
 complete -c hydra -f -n '__fish_use_subcommand' -a 'completion' -d 'Generate shell completion scripts'
 complete -c hydra -f -n '__fish_use_subcommand' -a 'version' -d 'Show version information'
 complete -c hydra -f -n '__fish_use_subcommand' -a 'help' -d 'Show help message'
+complete -c hydra -f -n '__fish_use_subcommand' -a 'group' -d 'Show or set session groups'
+complete -c hydra -f -n '__fish_use_subcommand' -a 'send' -d 'Queue a message to a session inbox'
+complete -c hydra -f -n '__fish_use_subcommand' -a 'recv' -d 'Read messages for the current session'
+complete -c hydra -f -n '__fish_use_subcommand' -a 'tail' -d 'View output from a session'
+complete -c hydra -f -n '__fish_use_subcommand' -a 'broadcast' -d 'Send a command to sessions'
+complete -c hydra -f -n '__fish_use_subcommand' -a 'wait-idle' -d 'Wait for sessions to become idle'
+complete -c hydra -f -n '__fish_use_subcommand' -a 'queue' -d 'Inspect or process the spawn queue'
 
 # Complete flags
 complete -c hydra -f -n '__fish_use_subcommand' -s h -l help -d 'Show help message'

--- a/lib/git.sh
+++ b/lib/git.sh
@@ -246,8 +246,45 @@ create_worktree() {
     return 0
 }
 
+# Check whether a worktree is safe to remove (dirty / untracked policy).
+# Usage: check_worktree_removable <path>
+# Returns: 0 if removal may proceed, 1 if dirty or the user aborted
+check_worktree_removable() {
+    path="$1"
+
+    if [ -z "$path" ] || [ ! -d "$path" ]; then
+        return 0
+    fi
+
+    if ! git -C "$path" diff --quiet -- 2>/dev/null || ! git -C "$path" diff --cached --quiet -- 2>/dev/null; then
+        echo "Error: Worktree has uncommitted changes" >&2
+        echo "Please commit or stash your changes first" >&2
+        return 1
+    fi
+
+    if [ -n "$(git -C "$path" ls-files --others --exclude-standard -- 2>/dev/null)" ]; then
+        if [ -z "${HYDRA_NONINTERACTIVE:-}" ] && [ -z "${CI:-}" ]; then
+            echo "Warning: Worktree has untracked files" >&2
+            printf "Continue anyway? [y/N] "
+            read -r response
+            case "$response" in
+                [yY][eE][sS]|[yY])
+                    ;;
+                *)
+                    echo "Aborted" >&2
+                    return 1
+                    ;;
+            esac
+        else
+            echo "Warning: Worktree has untracked files (proceeding in non-interactive mode)" >&2
+        fi
+    fi
+
+    return 0
+}
+
 # Delete a git worktree safely
-# Usage: delete_worktree <path> [force]
+# Usage: delete_worktree <path> [force|skip_preflight]
 # Returns: 0 on success, 1 on failure
 delete_worktree() {
     path="$1"
@@ -275,33 +312,10 @@ delete_worktree() {
         _invalidate_worktree_cache
         return 0
     fi
-    
-    # Check for uncommitted changes
-    if ! git -C "$path" diff --quiet -- 2>/dev/null || ! git -C "$path" diff --cached --quiet -- 2>/dev/null; then
-        echo "Error: Worktree has uncommitted changes" >&2
-        echo "Please commit or stash your changes first" >&2
-        return 1
-    fi
-    
-    # Check for untracked files (optional warning)
-    if [ -n "$(git -C "$path" ls-files --others --exclude-standard -- 2>/dev/null)" ]; then
-        # Check if we're in non-interactive mode
-        if [ -z "${HYDRA_NONINTERACTIVE:-}" ] && [ -z "${CI:-}" ]; then
-            # Interactive mode - prompt user
-            echo "Warning: Worktree has untracked files" >&2
-            printf "Continue anyway? [y/N] "
-            read -r response
-            case "$response" in
-                [yY][eE][sS]|[yY])
-                    ;;
-                *)
-                    echo "Aborted" >&2
-                    return 1
-                    ;;
-            esac
-        else
-            # Non-interactive mode - proceed with warning
-            echo "Warning: Worktree has untracked files (proceeding in non-interactive mode)" >&2
+
+    if [ "$force" != "skip_preflight" ]; then
+        if ! check_worktree_removable "$path"; then
+            return 1
         fi
     fi
     

--- a/lib/kill.sh
+++ b/lib/kill.sh
@@ -5,6 +5,18 @@
 # Provides session kill capabilities for single and bulk operations.
 # Dependencies: paths.sh, git.sh, tmux.sh, state.sh
 
+# Load message cleanup if available
+if ! command -v cleanup_messages_for_branch >/dev/null 2>&1; then
+    _kill_lib_dir="${HYDRA_LIB_DIR:-}"
+    if [ -z "$_kill_lib_dir" ]; then
+        _kill_lib_dir="$(cd "$(dirname "$0")/../lib" 2>/dev/null && pwd)" || true
+    fi
+    if [ -n "$_kill_lib_dir" ] && [ -f "$_kill_lib_dir/messages.sh" ]; then
+        # shellcheck disable=SC1090,SC1091
+        . "$_kill_lib_dir/messages.sh"
+    fi
+fi
+
 # Get worktree path for a branch with fallback
 # Usage: get_worktree_path_with_fallback <branch>
 # Returns: Worktree path on stdout, 1 if not found
@@ -30,6 +42,56 @@ get_worktree_path_with_fallback() {
     return 1
 }
 
+# Preflight a head before destroying tmux or state.
+# Usage: _kill_preflight <branch>
+# Returns: 0 if teardown may proceed, 1 if the worktree is not removable
+_kill_preflight() {
+    _pf_branch="$1"
+    _pf_path="$(get_worktree_path_with_fallback "$_pf_branch" || true)"
+    if [ -n "$_pf_path" ] && [ -d "$_pf_path" ]; then
+        _pf_norm="$(normalize_path "$_pf_path")"
+        if ! check_worktree_removable "$_pf_norm"; then
+            echo "Error: Refusing to kill '$_pf_branch'; session and mapping left intact" >&2
+            return 1
+        fi
+    fi
+    return 0
+}
+
+# Tear down tmux, mapping, worktree, and messages after a successful preflight.
+# Usage: _kill_teardown <branch> <session>
+# Returns: 0 on success, 1 if worktree deletion failed
+_kill_teardown() {
+    _td_branch="$1"
+    _td_session="$2"
+
+    if tmux_session_exists "$_td_session"; then
+        echo "  Killing tmux session '$_td_session'..."
+        if ! tmux kill-session -t "$_td_session" 2>/dev/null; then
+            echo "  Failed to kill tmux session '$_td_session'" >&2
+            return 1
+        fi
+    fi
+
+    remove_mapping "$_td_branch"
+
+    _td_path="$(get_worktree_path_with_fallback "$_td_branch" || true)"
+    if [ -n "$_td_path" ] && [ -d "$_td_path" ]; then
+        _td_norm="$(normalize_path "$_td_path")"
+        echo "  Removing worktree at '$_td_norm'..."
+        if ! delete_worktree "$_td_norm" "skip_preflight"; then
+            echo "  Failed to remove worktree for '$_td_branch'" >&2
+            return 1
+        fi
+    fi
+
+    if command -v cleanup_messages_for_branch >/dev/null 2>&1; then
+        cleanup_messages_for_branch "$_td_branch"
+    fi
+
+    return 0
+}
+
 # Kill a single hydra head (session + worktree + mapping)
 # Usage: kill_single_head <branch> <session>
 # Returns: 0 on success, 1 on failure
@@ -42,27 +104,12 @@ kill_single_head() {
         return 1
     fi
 
-    # Kill tmux session if it exists
-    if tmux_session_exists "$session"; then
-        echo "  Killing tmux session '$session'..."
-        if ! tmux kill-session -t "$session" 2>/dev/null; then
-            echo "  Failed to kill tmux session '$session'" >&2
-            return 1
-        fi
+    if ! _kill_preflight "$branch"; then
+        return 1
     fi
 
-    # Remove mapping
-    remove_mapping "$branch"
-
-    # Delete worktree using path function with fallback
-    worktree_path="$(get_worktree_path_with_fallback "$branch" || true)"
-    if [ -n "$worktree_path" ] && [ -d "$worktree_path" ]; then
-        normalized_path="$(normalize_path "$worktree_path")"
-        echo "  Removing worktree at '$normalized_path'..."
-        if ! delete_worktree "$normalized_path"; then
-            echo "  Failed to remove worktree for '$branch'" >&2
-            return 1
-        fi
+    if ! _kill_teardown "$branch" "$session"; then
+        return 1
     fi
 
     # Process pending spawn queue after successful kill (best-effort)
@@ -144,51 +191,24 @@ EOF
         echo ""
         echo "Killing hydra head '$branch' (session: $session)..."
 
-        # Kill tmux session
-        if tmux_session_exists "$session"; then
-            echo "  Killing tmux session '$session'..."
-            if tmux kill-session -t "$session" 2>/dev/null; then
-                # Remove mapping
-                remove_mapping "$branch"
+        if ! _kill_preflight "$branch"; then
+            failed=$((failed + 1))
+            continue
+        fi
 
-                # Delete worktree using path function with fallback
-                worktree_path="$(get_worktree_path_with_fallback "$branch" || true)"
-                if [ -n "$worktree_path" ] && [ -d "$worktree_path" ]; then
-                    normalized_path="$(normalize_path "$worktree_path")"
-                    echo "  Removing worktree at '$normalized_path'..."
-                    if delete_worktree "$normalized_path"; then
-                        succeeded=$((succeeded + 1))
-                        echo "  Successfully killed hydra head '$branch'"
-                    else
-                        failed=$((failed + 1))
-                        echo "  Failed to remove worktree for '$branch'" >&2
-                    fi
-                else
-                    # Session killed but no worktree found
-                    succeeded=$((succeeded + 1))
-                    echo "  Successfully killed session '$session' (no worktree found)"
-                fi
-            else
-                failed=$((failed + 1))
-                echo "  Failed to kill tmux session '$session'" >&2
-            fi
-        else
-            # Session doesn't exist - clean up mapping anyway
-            echo "  Session '$session' not found, cleaning up mapping..."
-            remove_mapping "$branch"
-
-            # Try to remove worktree if it exists (with fallback for outside-repo invocation)
-            worktree_path="$(get_worktree_path_with_fallback "$branch" || true)"
-            if [ -n "$worktree_path" ] && [ -d "$worktree_path" ]; then
-                normalized_path="$(normalize_path "$worktree_path")"
-                echo "  Removing orphaned worktree at '$normalized_path'..."
-                delete_worktree "$normalized_path"
-            fi
+        if _kill_teardown "$branch" "$session"; then
             succeeded=$((succeeded + 1))
+            echo "  Successfully killed hydra head '$branch'"
+        else
+            failed=$((failed + 1))
         fi
     done <<EOF
 $mappings
 EOF
+
+    if command -v process_spawn_queue >/dev/null 2>&1; then
+        process_spawn_queue >/dev/null 2>&1 || true
+    fi
 
     # Summary
     echo ""

--- a/lib/kill.sh
+++ b/lib/kill.sh
@@ -71,6 +71,8 @@ _kill_teardown() {
             echo "  Failed to kill tmux session '$_td_session'" >&2
             return 1
         fi
+    else
+        echo "  Session '$_td_session' not found, cleaning up mapping..."
     fi
 
     remove_mapping "$_td_branch"

--- a/lib/limits.sh
+++ b/lib/limits.sh
@@ -133,6 +133,9 @@ queue_spawn() {
     _group="${3:-}"
     _layout="${4:-default}"
     _priority="${5:-50}"
+    case "$_priority" in
+        ''|*[!0-9]*) _priority=50 ;;
+    esac
 
     if [ -z "$_branch" ]; then
         echo "Error: Branch name required" >&2
@@ -144,17 +147,31 @@ queue_spawn() {
     _timestamp="$(date +%s)"
     _safe_branch="$(printf '%s' "$_branch" | sed 's/[^a-zA-Z0-9_-]/_/g')"
 
-    # Format priority as 3-digit number (001-099)
-    _priority_fmt="$(printf '%03d' "$_priority")"
+    # Invert so higher priority sorts first under lexicographic find|sort
+    _sort_pri="$(printf '%03d' $((999 - _priority)))"
 
-    # Generate unique filename with PID for uniqueness
-    _seq="$$"
-    _filename="${_timestamp}_${_safe_branch}_${_seq}_${_priority_fmt}.queue"
-    _filepath="$(_get_queue_dir)/$_filename"
+    if ! acquire_lock "queue_add"; then
+        echo "Error: Failed to acquire queue lock" >&2
+        return 1
+    fi
 
-    # Atomic write with lock
-    if try_lock "queue_add"; then
-        cat > "$_filepath" <<EOF
+    _qdir="$(_get_queue_dir)"
+    _seq_file="$_qdir/.seq"
+    _seq=1
+    if [ -f "$_seq_file" ]; then
+        _seq="$(cat "$_seq_file" 2>/dev/null || echo 1)"
+        case "$_seq" in
+            ''|*[!0-9]*) _seq=1 ;;
+            *) _seq=$((_seq + 1)) ;;
+        esac
+    fi
+    printf '%s\n' "$_seq" > "$_seq_file"
+    _seq_fmt="$(printf '%06d' "$_seq")"
+
+    _filename="${_sort_pri}_${_timestamp}_${_seq_fmt}_${_safe_branch}.queue"
+    _filepath="$_qdir/$_filename"
+
+    cat > "$_filepath" <<EOF
 branch=$_branch
 ai_tool=$_ai_tool
 group=$_group
@@ -162,13 +179,9 @@ layout=$_layout
 priority=$_priority
 requested_at=$_timestamp
 EOF
-        release_lock "queue_add"
-        printf '%s' "$_filepath"
-        return 0
-    fi
-
-    echo "Error: Failed to acquire queue lock" >&2
-    return 1
+    release_lock "queue_add"
+    printf '%s' "$_filepath"
+    return 0
 }
 
 # Get count of queued spawns

--- a/lib/locks.sh
+++ b/lib/locks.sh
@@ -2,8 +2,14 @@
 # Lock management functions for Hydra
 # POSIX-compliant shell script
 #
-# Provides atomic locking for session name generation to prevent race conditions.
-# Locks are implemented using mkdir for POSIX atomicity.
+# Provides atomic locking via mkdir for POSIX atomicity, plus same-filesystem
+# replacement helpers for state files.
+# Do not introduce PID files here; that lock protocol belongs to a later release.
+
+if [ -n "${_LOCKS_MODULE_LOADED:-}" ]; then
+    return 0
+fi
+_LOCKS_MODULE_LOADED=1
 
 # Try to acquire a lock for a session name candidate
 # Usage: try_lock <candidate_name>
@@ -42,10 +48,59 @@ release_session_lock() {
     fi
 }
 
-# Clean up stale session-name locks (older than 60 seconds)
+# Acquire a lock with retries, then fail closed.
+# Usage: acquire_lock <name>
+# HYDRA_LOCK_RETRIES (default 5). Sleep 0.05s between tries when supported.
+# Returns: 0 if acquired, 1 if not
+acquire_lock() {
+    _al_name="$1"
+    _al_retries="${HYDRA_LOCK_RETRIES:-5}"
+    _al_i=0
+    case "$_al_retries" in
+        ''|*[!0-9]*) _al_retries=5 ;;
+    esac
+    while [ "$_al_i" -lt "$_al_retries" ]; do
+        if try_lock "$_al_name"; then
+            return 0
+        fi
+        _al_i=$((_al_i + 1))
+        if [ "$_al_i" -lt "$_al_retries" ]; then
+            sleep 0.05 2>/dev/null || sleep 1
+        fi
+    done
+    return 1
+}
+
+# Create a temporary file in the same directory as dest (same filesystem).
+# Usage: mktemp_adjacent <dest>
+# Returns: temp path on stdout
+mktemp_adjacent() {
+    _ma_dest="$1"
+    if [ -z "$_ma_dest" ]; then
+        return 1
+    fi
+    _ma_dir="$(dirname "$_ma_dest")"
+    if [ ! -d "$_ma_dir" ]; then
+        mkdir -p "$_ma_dir" || return 1
+    fi
+    mktemp "$_ma_dir/.hydra-tmp.XXXXXX"
+}
+
+# Atomically replace dest with tmpfile via rename. tmpfile must be same-FS.
+# Usage: atomic_replace <dest> <tmpfile>
+# Returns: 0 on success, 1 on failure
+atomic_replace() {
+    _ar_dest="$1"
+    _ar_tmp="$2"
+    if [ -z "$_ar_dest" ] || [ -z "$_ar_tmp" ] || [ ! -f "$_ar_tmp" ]; then
+        return 1
+    fi
+    mv "$_ar_tmp" "$_ar_dest"
+}
+
+# Clean up stale session-name locks (older than 60 seconds / 1 minute)
 # Usage: cleanup_stale_locks
 # Returns: 0 always (best-effort cleanup)
-# Note: This function was previously undefined but called in bin/hydra
 cleanup_stale_locks() {
     # Early return if no HYDRA_HOME or locks directory
     if [ -z "${HYDRA_HOME:-}" ]; then

--- a/lib/maintenance.sh
+++ b/lib/maintenance.sh
@@ -80,64 +80,39 @@ $(list_hydra_worktrees "$_repo_root")
 EOF
 }
 
-# Count stale lock directories (older than 60 seconds)
+# Count stale lock directories (mkdir *.lock dirs older than 1 minute)
 # Usage: count_stale_locks
 # Returns: Count on stdout
 count_stale_locks() {
-    _stale=0
-    if [ ! -d "${HYDRA_HOME:-}/locks" ]; then
+    if [ -z "${HYDRA_HOME:-}" ] || [ ! -d "$HYDRA_HOME/locks" ]; then
         printf '%s' "0"
         return 0
     fi
-    for _lock_dir in "$HYDRA_HOME/locks"/*; do
-        [ -d "$_lock_dir" ] || continue
-        _lock_age=0
-        if [ -f "$_lock_dir/pid" ]; then
-            if command -v stat >/dev/null 2>&1; then
-                if stat --version 2>&1 | grep -q GNU; then
-                    _lock_mtime="$(stat -c %Y "$_lock_dir/pid" 2>/dev/null || echo 0)"
-                else
-                    _lock_mtime="$(stat -f %m "$_lock_dir/pid" 2>/dev/null || echo 0)"
-                fi
-                _now="$(date +%s)"
-                _lock_age=$((_now - _lock_mtime))
-            fi
-        fi
-        if [ "$_lock_age" -gt 60 ]; then
-            _stale=$((_stale + 1))
-        fi
-    done
-    printf '%s' "$_stale"
+    _stale="$(find "$HYDRA_HOME/locks" -name "*.lock" -type d -mmin +1 2>/dev/null | wc -l | tr -d ' ')"
+    printf '%s' "${_stale:-0}"
 }
 
-# Remove stale lock directories
+# Remove stale lock directories (mkdir *.lock dirs older than 1 minute)
 # Usage: clean_stale_locks
 # Returns: Number removed on stdout
 clean_stale_locks() {
-    _cleaned=0
-    if [ ! -d "${HYDRA_HOME:-}/locks" ]; then
+    if [ -z "${HYDRA_HOME:-}" ] || [ ! -d "$HYDRA_HOME/locks" ]; then
         printf '%s' "0"
         return 0
     fi
-    for _lock_dir in "$HYDRA_HOME/locks"/*; do
-        [ -d "$_lock_dir" ] || continue
-        _lock_age=0
-        if [ -f "$_lock_dir/pid" ]; then
-            if command -v stat >/dev/null 2>&1; then
-                if stat --version 2>&1 | grep -q GNU; then
-                    _lock_mtime="$(stat -c %Y "$_lock_dir/pid" 2>/dev/null || echo 0)"
-                else
-                    _lock_mtime="$(stat -f %m "$_lock_dir/pid" 2>/dev/null || echo 0)"
-                fi
-                _now="$(date +%s)"
-                _lock_age=$((_now - _lock_mtime))
+    _cleaned=0
+    # Collect paths first so rmdir does not race with find
+    _stale_list="$(find "$HYDRA_HOME/locks" -name "*.lock" -type d -mmin +1 2>/dev/null || true)"
+    if [ -n "$_stale_list" ]; then
+        while IFS= read -r _lock_dir; do
+            [ -n "$_lock_dir" ] || continue
+            if rmdir "$_lock_dir" 2>/dev/null; then
+                _cleaned=$((_cleaned + 1))
             fi
-        fi
-        if [ "$_lock_age" -gt 60 ]; then
-            rm -rf "$_lock_dir"
-            _cleaned=$((_cleaned + 1))
-        fi
-    done
+        done <<EOF
+$_stale_list
+EOF
+    fi
     printf '%s' "$_cleaned"
 }
 
@@ -150,16 +125,47 @@ clean_dead_mappings() {
         printf '%s' "0"
         return 0
     fi
-    _tmpfile="$(mktemp)"
+
+    if ! acquire_lock "state_map"; then
+        echo "Error: Failed to acquire state lock" >&2
+        printf '%s' "0"
+        return 1
+    fi
+
+    _tmpfile="$(mktemp_adjacent "$HYDRA_MAP")" || {
+        release_lock "state_map"
+        printf '%s' "0"
+        return 1
+    }
+    _dead_branches=""
     while IFS=' ' read -r _branch _session _ai _group _timestamp _deps _pr; do
         if [ -n "$_session" ] && tmux_session_exists "$_session"; then
             printf '%s %s %s %s %s %s %s\n' \
                 "$_branch" "$_session" "${_ai:--}" "${_group:--}" "${_timestamp:--}" "${_deps:--}" "${_pr:--}" >> "$_tmpfile"
         else
             _dead_cleaned=$((_dead_cleaned + 1))
+            if [ -n "$_branch" ]; then
+                _dead_branches="${_dead_branches}${_branch}
+"
+            fi
         fi
     done < "$HYDRA_MAP"
-    mv "$_tmpfile" "$HYDRA_MAP"
+    if ! atomic_replace "$HYDRA_MAP" "$_tmpfile"; then
+        rm -f "$_tmpfile"
+        release_lock "state_map"
+        printf '%s' "0"
+        return 1
+    fi
     _invalidate_state_cache
+    release_lock "state_map"
+
+    if [ -n "$_dead_branches" ] && command -v cleanup_messages_for_branch >/dev/null 2>&1; then
+        while IFS= read -r _dead_b; do
+            [ -n "$_dead_b" ] || continue
+            cleanup_messages_for_branch "$_dead_b"
+        done <<EOF
+$_dead_branches
+EOF
+    fi
     printf '%s' "$_dead_cleaned"
 }

--- a/lib/output.sh
+++ b/lib/output.sh
@@ -50,9 +50,27 @@ print_summary_failure() {
 # Usage: json_escape <string>
 # Returns: Escaped string on stdout
 json_escape() {
-    # Escape backslashes, double quotes, tabs, and convert newlines to spaces
-    # (newlines in branch/session names are not expected, but ensure valid JSON)
-    printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' -e 's/	/\\t/g' | tr '\n' ' ' | sed 's/ $//'
+    # json_escape operates on POSIX C strings (NUL cannot appear in $1).
+    # Named JSON escapes for ", \, and common C0; remaining C0 as \\u00XX.
+    printf '%s' "$1" | od -An -v -tx1 | awk '
+    BEGIN {
+        for (i = 0; i < 256; i++) hex[sprintf("%02x", i)] = i
+    }
+    {
+        for (i = 1; i <= NF; i++) {
+            b = hex[tolower($i)]
+            if (b == 34) { printf "\\\""; continue }
+            if (b == 92) { printf "\\\\"; continue }
+            if (b == 8) { printf "\\b"; continue }
+            if (b == 9) { printf "\\t"; continue }
+            if (b == 10) { printf "\\n"; continue }
+            if (b == 12) { printf "\\f"; continue }
+            if (b == 13) { printf "\\r"; continue }
+            if (b < 32) { printf "\\u00%02x", b; continue }
+            printf "%c", b
+        }
+    }
+    '
 }
 
 # Output a JSON string key-value pair

--- a/lib/state.sh
+++ b/lib/state.sh
@@ -2,18 +2,40 @@
 # State management functions for Hydra
 # POSIX-compliant shell script
 
-# Load cache implementation (private API)
+# Load locks (required for fail-closed writers) then cache implementation
+_state_lib_dir="${HYDRA_LIB_DIR:-}"
+if [ -z "$_state_lib_dir" ]; then
+    _state_lib_dir="$(cd "$(dirname "$0")/../lib" 2>/dev/null && pwd)" || true
+fi
+if [ -z "${_LOCKS_MODULE_LOADED:-}" ] && [ -n "$_state_lib_dir" ] && [ -f "$_state_lib_dir/locks.sh" ]; then
+    # shellcheck disable=SC1090,SC1091
+    . "$_state_lib_dir/locks.sh"
+fi
 if [ -z "${_STATE_CACHE_MODULE_LOADED:-}" ]; then
-    _state_lib_dir="${HYDRA_LIB_DIR:-}"
-    if [ -z "$_state_lib_dir" ]; then
-        _state_lib_dir="$(cd "$(dirname "$0")/../lib" 2>/dev/null && pwd)" || true
-    fi
     if [ -n "$_state_lib_dir" ] && [ -f "$_state_lib_dir/state_cache.sh" ]; then
         # shellcheck disable=SC1090,SC1091
         . "$_state_lib_dir/state_cache.sh"
         _STATE_CACHE_MODULE_LOADED=1
     fi
 fi
+
+# Acquire the shared map lock or fail closed (no mutation).
+# Usage: _lock_state_map
+# Returns: 0 if held, 1 if not
+_lock_state_map() {
+    if ! acquire_lock "state_map"; then
+        echo "Error: Failed to acquire state lock" >&2
+        return 1
+    fi
+    return 0
+}
+
+# Format a 7-field map line
+# Usage: _format_map_line <branch> <session> <ai> <group> <timestamp> <deps> <pr>
+_format_map_line() {
+    printf '%s %s %s %s %s %s %s\n' \
+        "$1" "$2" "${3:--}" "${4:--}" "${5:--}" "${6:--}" "${7:--}"
+}
 
 # =============================================================================
 # Timestamp and Duration Helpers
@@ -70,6 +92,13 @@ get_duration_since() {
         return 0
     fi
 
+    case "$_ts" in
+        ''|*[!0-9]*)
+            echo "0"
+            return 0
+            ;;
+    esac
+
     _now="$(get_timestamp)"
     echo "$((_now - _ts))"
 }
@@ -108,24 +137,37 @@ add_mapping() {
     pr_field="${pr_number:-"-"}"
     mapping_line="$branch $session $ai_field $group_field $timestamp $deps_field $pr_field"
 
-    # Invalidate cache before write
+    if ! _lock_state_map; then
+        return 1
+    fi
+
     _invalidate_state_cache
 
-    # Use lock to make remove+add atomic
-    if try_lock "state_map"; then
-        # Remove existing mapping for this branch if any
-        remove_mapping "$branch" 2>/dev/null || true
-
-        echo "$mapping_line" >> "$HYDRA_MAP"
-
+    tmpfile="$(mktemp_adjacent "$HYDRA_MAP")" || {
         release_lock "state_map"
-        return 0
+        return 1
+    }
+
+    if [ -f "$HYDRA_MAP" ]; then
+        while IFS=' ' read -r map_branch map_session map_ai map_group map_timestamp map_deps map_pr; do
+            if [ -n "$map_branch" ] && [ "$map_branch" != "$branch" ]; then
+                _format_map_line "$map_branch" "$map_session" "$map_ai" "$map_group" \
+                    "$map_timestamp" "$map_deps" "$map_pr"
+            fi
+        done < "$HYDRA_MAP" > "$tmpfile"
     else
-        # Fallback if lock fails - still try the operation
-        remove_mapping "$branch" 2>/dev/null || true
-        echo "$mapping_line" >> "$HYDRA_MAP"
-        return 0
+        : > "$tmpfile"
     fi
+    printf '%s\n' "$mapping_line" >> "$tmpfile"
+
+    if ! atomic_replace "$HYDRA_MAP" "$tmpfile"; then
+        rm -f "$tmpfile"
+        release_lock "state_map"
+        return 1
+    fi
+
+    release_lock "state_map"
+    return 0
 }
 
 # Remove a branch-session mapping
@@ -143,25 +185,31 @@ remove_mapping() {
         return 0  # Nothing to remove
     fi
 
-    # Invalidate cache before write
+    if ! _lock_state_map; then
+        return 1
+    fi
+
     _invalidate_state_cache
 
-    # Create temporary file
-    tmpfile="$(mktemp)" || return 1
-    trap 'rm -f "$tmpfile"' EXIT INT TERM
+    tmpfile="$(mktemp_adjacent "$HYDRA_MAP")" || {
+        release_lock "state_map"
+        return 1
+    }
 
-    # Filter out the branch; preserve all columns for others
     while IFS=' ' read -r map_branch map_session map_ai map_group map_timestamp map_deps map_pr; do
-        if [ "$map_branch" != "$branch" ]; then
-            # Always use 7-field format for consistency
-            echo "$map_branch $map_session ${map_ai:-"-"} ${map_group:-"-"} ${map_timestamp:-"-"} ${map_deps:-"-"} ${map_pr:-"-"}"
+        if [ -n "$map_branch" ] && [ "$map_branch" != "$branch" ]; then
+            _format_map_line "$map_branch" "$map_session" "$map_ai" "$map_group" \
+                "$map_timestamp" "$map_deps" "$map_pr"
         fi
     done < "$HYDRA_MAP" > "$tmpfile"
 
-    # Replace original file
-    mv "$tmpfile" "$HYDRA_MAP"
-    trap - EXIT INT TERM
+    if ! atomic_replace "$HYDRA_MAP" "$tmpfile"; then
+        rm -f "$tmpfile"
+        release_lock "state_map"
+        return 1
+    fi
 
+    release_lock "state_map"
     return 0
 }
 
@@ -239,25 +287,30 @@ cleanup_mappings() {
         return 0
     fi
 
-    # Invalidate cache before write
+    if ! _lock_state_map; then
+        return 1
+    fi
+
     _invalidate_state_cache
 
-    # Create temporary file
-    tmpfile="$(mktemp)" || return 1
-    trap 'rm -f "$tmpfile"' EXIT INT TERM
+    tmpfile="$(mktemp_adjacent "$HYDRA_MAP")" || {
+        release_lock "state_map"
+        return 1
+    }
 
-    # Keep only valid mappings; preserve all fields
     while IFS=' ' read -r branch session ai group timestamp deps pr; do
-        if git_branch_exists "$branch" && tmux_session_exists "$session"; then
-            # Always use 7-field format for consistency
-            echo "$branch $session ${ai:-"-"} ${group:-"-"} ${timestamp:-"-"} ${deps:-"-"} ${pr:-"-"}"
+        if [ -n "$branch" ] && git_branch_exists "$branch" && tmux_session_exists "$session"; then
+            _format_map_line "$branch" "$session" "$ai" "$group" "$timestamp" "$deps" "$pr"
         fi
     done < "$HYDRA_MAP" > "$tmpfile"
 
-    # Replace original file
-    mv "$tmpfile" "$HYDRA_MAP"
-    trap - EXIT INT TERM
+    if ! atomic_replace "$HYDRA_MAP" "$tmpfile"; then
+        rm -f "$tmpfile"
+        release_lock "state_map"
+        return 1
+    fi
 
+    release_lock "state_map"
     return 0
 }
 
@@ -358,34 +411,43 @@ set_group() {
         return 1
     fi
 
-    # Invalidate cache before write
+    if ! _lock_state_map; then
+        return 1
+    fi
+
     _invalidate_state_cache
 
-    # Create temporary file
-    tmpfile="$(mktemp)" || return 1
-    trap 'rm -f "$tmpfile"' EXIT INT TERM
+    tmpfile="$(mktemp_adjacent "$HYDRA_MAP")" || {
+        release_lock "state_map"
+        return 1
+    }
 
     found=0
     while IFS=' ' read -r map_branch map_session map_ai map_group map_timestamp map_deps map_pr; do
         if [ "$map_branch" = "$branch" ]; then
             found=1
-            # Set new group (or placeholder if clearing), preserve all other fields
-            echo "$map_branch $map_session ${map_ai:-"-"} ${group:-"-"} ${map_timestamp:-"-"} ${map_deps:-"-"} ${map_pr:-"-"}"
-        else
-            # Preserve existing entry with all fields
-            echo "$map_branch $map_session ${map_ai:-"-"} ${map_group:-"-"} ${map_timestamp:-"-"} ${map_deps:-"-"} ${map_pr:-"-"}"
+            _format_map_line "$map_branch" "$map_session" "$map_ai" "${group:-"-"}" \
+                "$map_timestamp" "$map_deps" "$map_pr"
+        elif [ -n "$map_branch" ]; then
+            _format_map_line "$map_branch" "$map_session" "$map_ai" "$map_group" \
+                "$map_timestamp" "$map_deps" "$map_pr"
         fi
     done < "$HYDRA_MAP" > "$tmpfile"
 
     if [ "$found" -eq 0 ]; then
         echo "Error: Branch '$branch' not found in mappings" >&2
         rm -f "$tmpfile"
-        trap - EXIT INT TERM
+        release_lock "state_map"
         return 1
     fi
 
-    mv "$tmpfile" "$HYDRA_MAP"
-    trap - EXIT INT TERM
+    if ! atomic_replace "$HYDRA_MAP" "$tmpfile"; then
+        rm -f "$tmpfile"
+        release_lock "state_map"
+        return 1
+    fi
+
+    release_lock "state_map"
     return 0
 }
 
@@ -475,34 +537,43 @@ set_deps() {
         return 1
     fi
 
-    # Invalidate cache before write
+    if ! _lock_state_map; then
+        return 1
+    fi
+
     _invalidate_state_cache
 
-    # Create temporary file
-    tmpfile="$(mktemp)" || return 1
-    trap 'rm -f "$tmpfile"' EXIT INT TERM
+    tmpfile="$(mktemp_adjacent "$HYDRA_MAP")" || {
+        release_lock "state_map"
+        return 1
+    }
 
     found=0
     while IFS=' ' read -r map_branch map_session map_ai map_group map_timestamp map_deps map_pr; do
         if [ "$map_branch" = "$branch" ]; then
             found=1
-            # Set new deps (or placeholder if clearing), preserve all other fields
-            echo "$map_branch $map_session ${map_ai:-"-"} ${map_group:-"-"} ${map_timestamp:-"-"} ${deps:-"-"} ${map_pr:-"-"}"
-        else
-            # Preserve existing entry with all fields
-            echo "$map_branch $map_session ${map_ai:-"-"} ${map_group:-"-"} ${map_timestamp:-"-"} ${map_deps:-"-"} ${map_pr:-"-"}"
+            _format_map_line "$map_branch" "$map_session" "$map_ai" "$map_group" \
+                "$map_timestamp" "${deps:-"-"}" "$map_pr"
+        elif [ -n "$map_branch" ]; then
+            _format_map_line "$map_branch" "$map_session" "$map_ai" "$map_group" \
+                "$map_timestamp" "$map_deps" "$map_pr"
         fi
     done < "$HYDRA_MAP" > "$tmpfile"
 
     if [ "$found" -eq 0 ]; then
         echo "Error: Branch '$branch' not found in mappings" >&2
         rm -f "$tmpfile"
-        trap - EXIT INT TERM
+        release_lock "state_map"
         return 1
     fi
 
-    mv "$tmpfile" "$HYDRA_MAP"
-    trap - EXIT INT TERM
+    if ! atomic_replace "$HYDRA_MAP" "$tmpfile"; then
+        rm -f "$tmpfile"
+        release_lock "state_map"
+        return 1
+    fi
+
+    release_lock "state_map"
     return 0
 }
 
@@ -523,33 +594,42 @@ set_pr_for_branch() {
         return 1
     fi
 
-    # Invalidate cache before write
+    if ! _lock_state_map; then
+        return 1
+    fi
+
     _invalidate_state_cache
 
-    # Create temporary file
-    tmpfile="$(mktemp)" || return 1
-    trap 'rm -f "$tmpfile"' EXIT INT TERM
+    tmpfile="$(mktemp_adjacent "$HYDRA_MAP")" || {
+        release_lock "state_map"
+        return 1
+    }
 
     found=0
     while IFS=' ' read -r map_branch map_session map_ai map_group map_timestamp map_deps map_pr; do
         if [ "$map_branch" = "$branch" ]; then
             found=1
-            # Set new PR number (or placeholder if clearing), preserve all other fields
-            echo "$map_branch $map_session ${map_ai:-"-"} ${map_group:-"-"} ${map_timestamp:-"-"} ${map_deps:-"-"} ${pr_number:-"-"}"
-        else
-            # Preserve existing entry with all fields
-            echo "$map_branch $map_session ${map_ai:-"-"} ${map_group:-"-"} ${map_timestamp:-"-"} ${map_deps:-"-"} ${map_pr:-"-"}"
+            _format_map_line "$map_branch" "$map_session" "$map_ai" "$map_group" \
+                "$map_timestamp" "$map_deps" "${pr_number:-"-"}"
+        elif [ -n "$map_branch" ]; then
+            _format_map_line "$map_branch" "$map_session" "$map_ai" "$map_group" \
+                "$map_timestamp" "$map_deps" "$map_pr"
         fi
     done < "$HYDRA_MAP" > "$tmpfile"
 
     if [ "$found" -eq 0 ]; then
         echo "Error: Branch '$branch' not found in mappings" >&2
         rm -f "$tmpfile"
-        trap - EXIT INT TERM
+        release_lock "state_map"
         return 1
     fi
 
-    mv "$tmpfile" "$HYDRA_MAP"
-    trap - EXIT INT TERM
+    if ! atomic_replace "$HYDRA_MAP" "$tmpfile"; then
+        rm -f "$tmpfile"
+        release_lock "state_map"
+        return 1
+    fi
+
+    release_lock "state_map"
     return 0
 }

--- a/lib/state_cache.sh
+++ b/lib/state_cache.sh
@@ -34,11 +34,18 @@ _validate_and_repair_state_file() {
     done < "$HYDRA_MAP"
 
     if [ "$malformed" -gt 0 ]; then
+        if ! acquire_lock "state_map"; then
+            echo "Warning: State file has $malformed malformed line(s); lock busy, skipping repair" >&2
+            return 0
+        fi
+
         # Backup corrupted file
         cp "$HYDRA_MAP" "${HYDRA_MAP}.bak" 2>/dev/null || true
 
-        # Filter out malformed lines
-        tmpfile="$(mktemp)"
+        tmpfile="$(mktemp_adjacent "$HYDRA_MAP")" || {
+            release_lock "state_map"
+            return 1
+        }
         while IFS= read -r line; do
             [ -z "$line" ] && continue
             # Count fields using POSIX word splitting (perf: avoid awk)
@@ -48,7 +55,12 @@ _validate_and_repair_state_file() {
                 echo "$line" >> "$tmpfile"
             fi
         done < "$HYDRA_MAP"
-        mv "$tmpfile" "$HYDRA_MAP"
+        if ! atomic_replace "$HYDRA_MAP" "$tmpfile"; then
+            rm -f "$tmpfile"
+            release_lock "state_map"
+            return 1
+        fi
+        release_lock "state_map"
 
         echo "Warning: Repaired $malformed malformed line(s) in state file" >&2
         echo "  Backup saved to: ${HYDRA_MAP}.bak" >&2

--- a/lib/tmux.sh
+++ b/lib/tmux.sh
@@ -57,8 +57,165 @@ tmux_session_exists() {
     if [ -z "$session" ]; then
         return 1
     fi
-    
+
+    if [ -n "${_TMUX_SNAPSHOT_LOADED:-}" ]; then
+        printf '%s\n' "$_TMUX_SNAPSHOT_SESSIONS" | grep -Fqx "$session"
+        return $?
+    fi
+
     tmux has-session -t "$session" 2>/dev/null
+}
+
+# Load a one-shot snapshot of sessions and panes for batch observation.
+# Usage: tmux_load_snapshot
+# Sets: _TMUX_SNAPSHOT_LOADED, _TMUX_SNAPSHOT_SESSIONS, _TMUX_SNAPSHOT_PANES
+# Pane lines: session<TAB>window_index<TAB>pane_index<TAB>window_activity<TAB>pane_current_command<TAB>pane_dead
+tmux_load_snapshot() {
+    _TMUX_SNAPSHOT_SESSIONS="$(tmux list-sessions -F '#{session_name}' 2>/dev/null || true)"
+    _TMUX_SNAPSHOT_PANES="$(tmux list-panes -a -F '#{session_name}	#{window_index}	#{pane_index}	#{window_activity}	#{pane_current_command}	#{pane_dead}' 2>/dev/null || true)"
+    _TMUX_SNAPSHOT_LOADED=1
+}
+
+# Clear a previously loaded tmux snapshot (callers fall back to live probes).
+# Usage: tmux_clear_snapshot
+tmux_clear_snapshot() {
+    _TMUX_SNAPSHOT_LOADED=""
+    _TMUX_SNAPSHOT_SESSIONS=""
+    _TMUX_SNAPSHOT_PANES=""
+}
+
+# Latest window_activity timestamp for a session from the snapshot.
+# Usage: tmux_snapshot_window_activity <session>
+# Returns: unix timestamp or 0
+tmux_snapshot_window_activity() {
+    _sa_session="$1"
+    if [ -z "${_TMUX_SNAPSHOT_PANES:-}" ]; then
+        printf '%s' "0"
+        return 0
+    fi
+    printf '%s\n' "$_TMUX_SNAPSHOT_PANES" | awk -F '	' -v s="$_sa_session" '
+        $1 == s {
+            act = $4 + 0
+            if (act > max) max = act
+        }
+        END { print max + 0 }
+    '
+}
+
+# True if every pane in the session is marked pane_dead.
+# Usage: tmux_snapshot_session_dead <session>
+# Returns: 0 if all panes dead, 1 otherwise
+tmux_snapshot_session_dead() {
+    _sd_session="$1"
+    if [ -z "${_TMUX_SNAPSHOT_PANES:-}" ]; then
+        return 1
+    fi
+    printf '%s\n' "$_TMUX_SNAPSHOT_PANES" | awk -F '	' -v s="$_sd_session" '
+        $1 == s { seen = 1; if ($6 != "1") live = 1 }
+        END { if (seen && !live) exit 0; exit 1 }
+    '
+}
+
+# WARNING: SECURITY SENSITIVE
+# This function executes arbitrary commands in tmux sessions.
+# Only call with trusted, validated input - never with user input.
+# Commands are executed with the user's shell privileges.
+#
+# Send keys to an explicit tmux target (session:window.pane).
+# Usage: send_keys_to_target <session_name> <pane_target> <keys>
+# Returns: 0 on success, 1 on failure
+send_keys_to_target() {
+    session="$1"
+    pane_target="$2"
+    keys="$3"
+
+    if [ -z "$session" ] || [ -z "$pane_target" ] || [ -z "$keys" ]; then
+        echo "Error: Session name, pane target, and keys are required" >&2
+        return 1
+    fi
+
+    if ! tmux_session_exists "$session"; then
+        echo "Error: Session does not exist: $session" >&2
+        return 1
+    fi
+
+    tmux send-keys -t "$pane_target" "$keys" Enter || return 1
+
+    return 0
+}
+
+# Send keys to the primary pane (session:0.0), never "whatever is active".
+# Usage: send_keys_to_session <session_name> <keys>
+# Returns: 0 on success, 1 on failure
+send_keys_to_session() {
+    session="$1"
+    keys="$2"
+
+    if [ -z "$session" ] || [ -z "$keys" ]; then
+        echo "Error: Session name and keys are required" >&2
+        return 1
+    fi
+
+    send_keys_to_target "$session" "${session}:0.0" "$keys"
+}
+
+# Resolve a shell pane for broadcast. Prefer a non-agent pane.
+# Usage: find_broadcast_pane <session> [ai_tool]
+# Prints session:window.pane on stdout. Returns 1 if only the agent pane exists.
+find_broadcast_pane() {
+    _fb_session="$1"
+    _fb_ai="${2:-}"
+
+    if [ -z "$_fb_session" ]; then
+        return 1
+    fi
+
+    _fb_panes="$(tmux list-panes -t "$_fb_session" -F '#{window_index}.#{pane_index} #{pane_current_command}' 2>/dev/null || true)"
+    if [ -z "$_fb_panes" ]; then
+        return 1
+    fi
+
+    _fb_shell=""
+    _fb_has_agent_slot=0
+    if [ -n "$_fb_ai" ] && [ "$_fb_ai" != "-" ]; then
+        _fb_has_agent_slot=1
+    fi
+
+    while IFS=' ' read -r _fb_idx _fb_cmd; do
+        [ -n "$_fb_idx" ] || continue
+        _fb_is_shell=0
+        case "$_fb_cmd" in
+            sh|bash|dash|zsh|fish|-sh|-bash|-dash|-zsh|-fish)
+                _fb_is_shell=1
+                ;;
+        esac
+        if [ "$_fb_idx" = "0.0" ] && [ "$_fb_has_agent_slot" -eq 1 ]; then
+            continue
+        fi
+        if [ "$_fb_is_shell" -eq 1 ]; then
+            _fb_shell="${_fb_session}:${_fb_idx}"
+            break
+        fi
+        if [ "$_fb_has_agent_slot" -eq 1 ] && [ "$_fb_idx" != "0.0" ]; then
+            # Non-primary pane even if command is not a classic shell name
+            _fb_shell="${_fb_session}:${_fb_idx}"
+            break
+        fi
+    done <<EOF
+$_fb_panes
+EOF
+
+    if [ -n "$_fb_shell" ]; then
+        printf '%s\n' "$_fb_shell"
+        return 0
+    fi
+
+    if [ "$_fb_has_agent_slot" -eq 1 ]; then
+        return 1
+    fi
+
+    printf '%s\n' "${_fb_session}:0.0"
+    return 0
 }
 
 # Create a new tmux session
@@ -115,33 +272,6 @@ kill_session() {
 # Returns: Session names on stdout
 list_sessions() {
     tmux list-sessions -F '#{session_name}' 2>/dev/null || true
-}
-
-# WARNING: SECURITY SENSITIVE
-# This function executes arbitrary commands in tmux sessions.
-# Only call with trusted, validated input - never with user input.
-# Commands are executed with the user's shell privileges.
-#
-# Send keys to a tmux session
-# Usage: send_keys_to_session <session_name> <keys>
-# Returns: 0 on success, 1 on failure
-send_keys_to_session() {
-    session="$1"
-    keys="$2"
-    
-    if [ -z "$session" ] || [ -z "$keys" ]; then
-        echo "Error: Session name and keys are required" >&2
-        return 1
-    fi
-    
-    if ! tmux_session_exists "$session"; then
-        echo "Error: Session does not exist: $session" >&2
-        return 1
-    fi
-    
-    tmux send-keys -t "$session" "$keys" Enter || return 1
-    
-    return 0
 }
 
 # Switch to a tmux session

--- a/lib/tui_actions.sh
+++ b/lib/tui_actions.sh
@@ -257,7 +257,7 @@ tui_action_kill_all() {
             # Kill all except current session
             killed=0
             skipped=0
-            while IFS='	' read -r branch session _ai _status _tag _activity; do
+            while IFS='	' read -r branch session _ai _status _tag _activity _group _pr; do
                 [ -z "$branch" ] && continue
                 if [ "$session" = "$TUI_CURRENT_SESSION" ]; then
                     skipped=1

--- a/lib/tui_data.sh
+++ b/lib/tui_data.sh
@@ -22,6 +22,10 @@ tui_build_list() {
         return 0
     fi
 
+    # Batch tmux observation for this refresh
+    tmux_load_snapshot
+    _now="$(date +%s)"
+
     # Read mappings and write to temp file with status
     # Use tab as delimiter (safe - branch/session names can't contain tabs)
     while IFS=' ' read -r branch session ai group _ts _deps _pr; do
@@ -29,9 +33,16 @@ tui_build_list() {
 
         if tmux_session_exists "$session" 2>/dev/null; then
             sess_status="ALIVE"
-
-            # Activity check — skip capture-pane if cached hash is fresh
             activity="IDLE"
+
+            _win_act="$(tmux_snapshot_window_activity "$session")"
+            case "$_win_act" in
+                ''|*[!0-9]*) _win_act=0 ;;
+            esac
+            if [ "$_win_act" -gt 0 ] && [ "$((_now - _win_act))" -lt 5 ]; then
+                activity="BUSY"
+            elif [ "$_win_act" -eq 0 ]; then
+                # Fallback: pane hashing when window_activity is unavailable
             if [ -n "$TUI_ACTIVITY_DIR" ] && [ -d "$TUI_ACTIVITY_DIR" ]; then
                 hash_file="$TUI_ACTIVITY_DIR/${session}.hash"
                 time_file="$TUI_ACTIVITY_DIR/${session}.time"
@@ -70,6 +81,7 @@ tui_build_list() {
                         activity="BUSY"
                     fi
                 fi
+            fi
             fi
         else
             sess_status="DEAD"
@@ -130,7 +142,7 @@ tui_build_list() {
 
 # Get session data at index
 # Usage: tui_get_session_at <index>
-# Returns: session data on stdout (branch|session|ai|status)
+# Returns: session data on stdout (tab-separated: branch session ai status tag activity group pr)
 tui_get_session_at() {
     idx="$1"
     sed -n "$((idx + 1))p" "$TUI_TEMP_LIST"

--- a/lib/tui_render.sh
+++ b/lib/tui_render.sh
@@ -211,9 +211,9 @@ tui_render() {
         printf "\n"
     fi
 
-    # Render visible items (tab-delimited with 6 fields)
+    # Render visible items (tab-delimited: branch session ai status tag activity group pr)
     idx=0
-    while IFS='	' read -r branch session ai status tag activity; do
+    while IFS='	' read -r branch session ai status tag activity group pr; do
         [ -z "$branch" ] && continue
 
         # Skip items before visible range
@@ -263,6 +263,15 @@ tui_render() {
             esac
         fi
 
+        group_str=""
+        if [ -n "$group" ] && [ "$group" != "-" ]; then
+            group_str=" ${TUI_DIM}[$group]${TUI_RESET}"
+        fi
+        pr_str=""
+        if [ -n "$pr" ] && [ "$pr" != "-" ]; then
+            pr_str=" ${TUI_DIM}#${pr}${TUI_RESET}"
+        fi
+
         # Current session marker (uses cached TUI_CURRENT_SESSION)
         current_str=""
         if [ "$session" = "$TUI_CURRENT_SESSION" ]; then
@@ -270,7 +279,7 @@ tui_render() {
         fi
 
         # Build display line
-        line="$status_str $branch -> $session$ai_str$tag_str$current_str"
+        line="$status_str $branch -> $session$ai_str$tag_str$group_str$pr_str$current_str"
 
         # Multi-select indicator
         select_marker="  "

--- a/lib/tui_tags.sh
+++ b/lib/tui_tags.sh
@@ -37,8 +37,15 @@ tui_set_tag() {
         return 1
     fi
 
-    # Create temp file for atomic update
-    _tmpfile="$(mktemp)" || return 1
+    if ! acquire_lock "tags"; then
+        echo "Error: Failed to acquire tags lock" >&2
+        return 1
+    fi
+
+    _tmpfile="$(mktemp_adjacent "$TUI_TAGS_FILE")" || {
+        release_lock "tags"
+        return 1
+    }
 
     # Copy all entries except the one being updated
     if [ -f "$TUI_TAGS_FILE" ]; then
@@ -54,11 +61,16 @@ tui_set_tag() {
         printf "%s %s\n" "$_branch" "$_tag" >> "$_tmpfile"
     fi
 
-    # Atomic move
-    mv "$_tmpfile" "$TUI_TAGS_FILE" 2>/dev/null || {
+    if [ ! -s "$_tmpfile" ]; then
+        : > "$_tmpfile"
+    fi
+
+    if ! atomic_replace "$TUI_TAGS_FILE" "$_tmpfile"; then
         rm -f "$_tmpfile"
+        release_lock "tags"
         return 1
-    }
+    fi
+    release_lock "tags"
     return 0
 }
 

--- a/lib/yaml.sh
+++ b/lib/yaml.sh
@@ -222,7 +222,7 @@ apply_yaml_config() {
             fi
             ;;
           START)
-            tmux send-keys -t "$session" "$f1" Enter 2>/dev/null || true
+            tmux send-keys -t "${session}:0.0" "$f1" Enter 2>/dev/null || true
             ;;
         esac
       done

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -77,10 +77,16 @@ for n in $COUNTS; do
         # shellcheck disable=SC1091
         . "$HYDRA_ROOT/lib/tui.sh"
         TUI_TEMP_LIST="$(mktemp)"
+        # Used by tui_build_list (sourced globals)
+        # shellcheck disable=SC2034
         TUI_ITEM_COUNT=0
+        # shellcheck disable=SC2034
         TUI_SELECTED=0
+        # shellcheck disable=SC2034
         TUI_OFFSET=0
+        # shellcheck disable=SC2034
         TUI_ROWS=24
+        # shellcheck disable=SC2034
         TUI_ACTIVITY_DIR=""
         _start="$(date +%s%N 2>/dev/null || date +%s)"
         tui_build_list

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -1,0 +1,103 @@
+#!/bin/sh
+# Record shell baseline timings. Not a CI gate; prints measurements only.
+# Usage: sh scripts/bench.sh [heads...]
+# Default head counts: 5 20
+
+set -eu
+
+HYDRA_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+HYDRA_BIN="$HYDRA_ROOT/bin/hydra"
+COUNTS="${*:-5 20}"
+
+if ! command -v tmux >/dev/null 2>&1; then
+    echo "bench: tmux is required" >&2
+    exit 1
+fi
+if ! command -v git >/dev/null 2>&1; then
+    echo "bench: git is required" >&2
+    exit 1
+fi
+
+_time_cmd() {
+    _label="$1"
+    shift
+    _start="$(date +%s%N 2>/dev/null || date +%s)"
+    "$@" >/dev/null 2>&1 || true
+    _end="$(date +%s%N 2>/dev/null || date +%s)"
+    if [ ${#_start} -gt 10 ]; then
+        _ms=$(( (_end - _start) / 1000000 ))
+        printf '  %s: %sms\n' "$_label" "$_ms"
+    else
+        printf '  %s: %ss\n' "$_label" "$((_end - _start))"
+    fi
+}
+
+echo "Hydra shell baseline (measurements only; no speedup claims)"
+echo "host=$(uname -s) arch=$(uname -m) tmux=$(tmux -V 2>/dev/null || echo unknown)"
+
+for n in $COUNTS; do
+    work="$(mktemp -d)"
+    home="$work/hydra-home"
+    repo="$work/repo"
+    mkdir -p "$home" "$repo"
+    git -C "$repo" init -q
+    git -C "$repo" config user.email "bench@example.com"
+    git -C "$repo" config user.name "bench"
+    echo "ok" > "$repo/README"
+    git -C "$repo" add README
+    git -C "$repo" commit -q -m init
+
+    i=1
+    while [ "$i" -le "$n" ]; do
+        env HYDRA_HOME="$home" HYDRA_ROOT="$HYDRA_ROOT" HYDRA_SKIP_AI=1 \
+            HYDRA_NONINTERACTIVE=1 \
+            "$HYDRA_BIN" spawn "bench-$i" >/dev/null 2>&1 || true
+        i=$((i + 1))
+    done
+
+    echo ""
+    echo "heads=$n"
+    _time_cmd "list" env HYDRA_HOME="$home" HYDRA_ROOT="$HYDRA_ROOT" "$HYDRA_BIN" list
+    _time_cmd "status" env HYDRA_HOME="$home" HYDRA_ROOT="$HYDRA_ROOT" "$HYDRA_BIN" status
+    _time_cmd "doctor" env HYDRA_HOME="$home" HYDRA_ROOT="$HYDRA_ROOT" "$HYDRA_BIN" doctor
+
+    # TUI refresh (tui_build_list) without an interactive terminal
+    TUI_MS="$({
+        export HYDRA_HOME="$home"
+        export HYDRA_MAP="$home/map"
+        export HYDRA_LIB_DIR="$HYDRA_ROOT/lib"
+        # shellcheck disable=SC1091
+        . "$HYDRA_ROOT/lib/output.sh"
+        # shellcheck disable=SC1091
+        . "$HYDRA_ROOT/lib/locks.sh"
+        # shellcheck disable=SC1091
+        . "$HYDRA_ROOT/lib/tmux.sh"
+        # shellcheck disable=SC1091
+        . "$HYDRA_ROOT/lib/state.sh"
+        # shellcheck disable=SC1091
+        . "$HYDRA_ROOT/lib/tui.sh"
+        TUI_TEMP_LIST="$(mktemp)"
+        TUI_ITEM_COUNT=0
+        TUI_SELECTED=0
+        TUI_OFFSET=0
+        TUI_ROWS=24
+        TUI_ACTIVITY_DIR=""
+        _start="$(date +%s%N 2>/dev/null || date +%s)"
+        tui_build_list
+        _end="$(date +%s%N 2>/dev/null || date +%s)"
+        rm -f "$TUI_TEMP_LIST"
+        if [ ${#_start} -gt 10 ]; then
+            echo $(( (_end - _start) / 1000000 ))
+        else
+            echo $(( _end - _start ))
+        fi
+    })"
+    printf '  tui_build_list: %sms\n' "$TUI_MS"
+
+    env HYDRA_HOME="$home" HYDRA_ROOT="$HYDRA_ROOT" HYDRA_NONINTERACTIVE=1 \
+        "$HYDRA_BIN" kill --all --force >/dev/null 2>&1 || true
+    tmux list-sessions -F '#{session_name}' 2>/dev/null | grep '^bench-' | while IFS= read -r s; do
+        tmux kill-session -t "$s" 2>/dev/null || true
+    done
+    rm -rf "$work"
+done

--- a/tests/bin/tmux
+++ b/tests/bin/tmux
@@ -1,0 +1,90 @@
+#!/bin/sh
+# Deterministic tmux stub for Hydra unit tests.
+# Enable by prepending this directory to PATH.
+#
+# Environment:
+#   HYDRA_TEST_TMUX_LOG       append argv lines here
+#   HYDRA_TEST_TMUX_SESSIONS  newline-separated session names
+#   HYDRA_TEST_TMUX_PANES     lines of:
+#     session<TAB>window_index<TAB>pane_index<TAB>window_activity<TAB>command<TAB>dead
+
+if [ -n "${HYDRA_TEST_TMUX_LOG:-}" ]; then
+    # shellcheck disable=SC2124
+    printf '%s\n' "$*" >> "$HYDRA_TEST_TMUX_LOG"
+fi
+
+cmd="$1"
+[ -n "$cmd" ] && shift
+
+_has_session() {
+    _name="$1"
+    [ -n "$_name" ] || return 1
+    printf '%s\n' "${HYDRA_TEST_TMUX_SESSIONS:-}" | grep -Fqx "$_name"
+}
+
+case "$cmd" in
+    -V)
+        echo "tmux 3.3a"
+        exit 0
+        ;;
+    has-session)
+        _target=""
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                -t) shift; _target="$1" ;;
+            esac
+            shift
+        done
+        _has_session "$_target"
+        exit $?
+        ;;
+    list-sessions)
+        if [ -n "${HYDRA_TEST_TMUX_SESSIONS:-}" ]; then
+            printf '%s\n' "$HYDRA_TEST_TMUX_SESSIONS"
+        fi
+        exit 0
+        ;;
+    list-panes)
+        _filter=""
+        _fmt=""
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                -t) shift; _filter="$1"; shift ;;
+                -F) shift; _fmt="$1"; shift ;;
+                -a) shift ;;
+                *) shift ;;
+            esac
+        done
+        if [ -z "${HYDRA_TEST_TMUX_PANES:-}" ]; then
+            exit 0
+        fi
+        printf '%s\n' "$HYDRA_TEST_TMUX_PANES" | while IFS='	' read -r s w p act cmd dead; do
+            [ -n "$s" ] || continue
+            if [ -n "$_filter" ] && [ "$s" != "$_filter" ]; then
+                continue
+            fi
+            case "$_fmt" in
+                *window_index}.#{pane_index*)
+                    printf '%s.%s %s\n' "$w" "$p" "$cmd"
+                    ;;
+                *)
+                    printf '%s\t%s\t%s\t%s\t%s\t%s\n' "$s" "$w" "$p" "$act" "$cmd" "$dead"
+                    ;;
+            esac
+        done
+        exit 0
+        ;;
+    send-keys|kill-session|new-session|rename-session|switch-client|attach-session|select-pane|select-window|split-window|kill-pane|select-layout|set-window-option|display-message)
+        if [ "$cmd" = "display-message" ]; then
+            echo "${HYDRA_TEST_TMUX_CURRENT:-}"
+        fi
+        exit 0
+        ;;
+    capture-pane)
+        echo "${HYDRA_TEST_TMUX_CAPTURE:-pane}"
+        exit 0
+        ;;
+    *)
+        exit 0
+        ;;
+esac

--- a/tests/test_completion.sh
+++ b/tests/test_completion.sh
@@ -196,6 +196,50 @@ test_generate_completion_empty() {
     test_count=$((test_count + 1))
 }
 
+test_completion_includes_shipped_commands() {
+    echo "Testing completion lists shipped commands..."
+
+    bash_out=$(generate_completion bash)
+    zsh_out=$(generate_completion zsh)
+    fish_out=$(generate_completion fish)
+
+    for cmd in spawn list switch kill regenerate status doctor dashboard dashboard-exit cycle-layout tui cleanup pr template completion version help group send recv tail broadcast wait-idle queue; do
+        case "$bash_out" in
+            *"$cmd"*)
+                echo "[PASS] bash completion includes $cmd"
+                pass_count=$((pass_count + 1))
+                ;;
+            *)
+                echo "[FAIL] bash completion includes $cmd"
+                fail_count=$((fail_count + 1))
+                ;;
+        esac
+        test_count=$((test_count + 1))
+        case "$zsh_out" in
+            *"$cmd"*)
+                echo "[PASS] zsh completion includes $cmd"
+                pass_count=$((pass_count + 1))
+                ;;
+            *)
+                echo "[FAIL] zsh completion includes $cmd"
+                fail_count=$((fail_count + 1))
+                ;;
+        esac
+        test_count=$((test_count + 1))
+        case "$fish_out" in
+            *"$cmd"*)
+                echo "[PASS] fish completion includes $cmd"
+                pass_count=$((pass_count + 1))
+                ;;
+            *)
+                echo "[FAIL] fish completion includes $cmd"
+                fail_count=$((fail_count + 1))
+                ;;
+        esac
+        test_count=$((test_count + 1))
+    done
+}
+
 # Run all tests
 echo "=== Completion Tests ==="
 echo ""
@@ -211,6 +255,8 @@ echo ""
 test_generate_completion_unknown
 echo ""
 test_generate_completion_empty
+echo ""
+test_completion_includes_shipped_commands
 echo ""
 
 # Print summary

--- a/tests/test_json_output.sh
+++ b/tests/test_json_output.sh
@@ -152,8 +152,38 @@ test_json_escape_newlines() {
     input="$(printf 'hello\nworld')"
     result="$(json_escape "$input")"
 
-    # Newlines should be converted to spaces
-    assert_equal "hello world" "$result" "Newlines converted to spaces"
+    # Newlines should be escaped as \n
+    assert_equal 'hello\nworld' "$result" "Newlines escaped as \\n"
+}
+
+test_json_escape_cr_ff_bs() {
+    echo ""
+    echo "Testing json_escape with CR, FF, and backspace..."
+
+    input="$(printf 'a\rb')"
+    result="$(json_escape "$input")"
+    assert_equal 'a\rb' "$result" "CR escaped as \\r"
+
+    input="$(printf 'a\fb')"
+    result="$(json_escape "$input")"
+    assert_equal 'a\fb' "$result" "FF escaped as \\f"
+
+    input="$(printf 'a\bb')"
+    result="$(json_escape "$input")"
+    assert_equal 'a\bb' "$result" "BS escaped as \\b"
+}
+
+test_json_escape_other_c0() {
+    echo ""
+    echo "Testing json_escape with other C0 bytes..."
+
+    input="$(printf 'a\001b')"
+    result="$(json_escape "$input")"
+    assert_equal 'a\u0001b' "$result" "SOH escaped as \\u0001"
+
+    input="$(printf 'a\037b')"
+    result="$(json_escape "$input")"
+    assert_equal 'a\u001fb' "$result" "US escaped as \\u001f"
 }
 
 test_json_escape_mixed_special() {
@@ -323,6 +353,41 @@ test_status_json() {
     cleanup_test_env
 }
 
+test_status_json_seven_field_map() {
+    echo ""
+    echo "Testing hydra status --json with deps and pr fields..."
+
+    setup_test_env
+    HYDRA_MAP="$HYDRA_HOME/map"
+    timestamp="$(date +%s)"
+    echo "stat-branch missing-sess claude grp $timestamp depA,depB 42" > "$HYDRA_MAP"
+
+    output="$(env HYDRA_HOME="$HYDRA_HOME" "$HYDRA_BIN" status --json 2>&1)" || true
+
+    if echo "$output" | grep -q "Illegal number"; then
+        echo "[FAIL] status must not print Illegal number"
+        fail_count=$((fail_count + 1))
+    else
+        echo "[PASS] status must not print Illegal number"
+        pass_count=$((pass_count + 1))
+    fi
+    test_count=$((test_count + 1))
+
+    if validate_json "$output"; then
+        echo "[PASS] status --json with 7-field map is valid JSON"
+        pass_count=$((pass_count + 1))
+    else
+        echo "[FAIL] status --json with 7-field map is valid JSON"
+        echo "  Output: $output"
+        fail_count=$((fail_count + 1))
+    fi
+    test_count=$((test_count + 1))
+
+    assert_contains "$output" "duration_seconds" "JSON contains duration_seconds"
+
+    cleanup_test_env
+}
+
 # =============================================================================
 # Main test runner
 # =============================================================================
@@ -338,6 +403,8 @@ main() {
     test_json_escape_backslashes
     test_json_escape_tabs
     test_json_escape_newlines
+    test_json_escape_cr_ff_bs
+    test_json_escape_other_c0
     test_json_escape_mixed_special
 
     # Unit tests for JSON helpers
@@ -355,6 +422,7 @@ main() {
     test_list_json_empty
     test_list_json_with_sessions
     test_status_json
+    test_status_json_seven_field_map
 
     # Report results
     echo ""

--- a/tests/test_kill.sh
+++ b/tests/test_kill.sh
@@ -225,6 +225,84 @@ test_kill_group_sessions_nonexistent_group() {
     cleanup_test_env "$test_dir"
 }
 
+test_kill_dirty_worktree_preflight() {
+    echo ""
+    echo "Testing kill_single_head refuses dirty worktree before teardown..."
+
+    repo="$(mktemp -d)"
+    parent="$(dirname "$repo")"
+    git -C "$repo" init -q
+    git -C "$repo" config user.email "t@example.com"
+    git -C "$repo" config user.name "t"
+    echo x > "$repo/file"
+    git -C "$repo" add file
+    git -C "$repo" commit -q -m init
+    git -C "$repo" branch dirty-kill
+    wt="$parent/hydra-dirty-kill"
+    git -C "$repo" worktree add -q "$wt" dirty-kill
+    echo dirty >> "$wt/file"
+
+    HYDRA_HOME="$(mktemp -d)"
+    HYDRA_MAP="$HYDRA_HOME/map"
+    export HYDRA_HOME HYDRA_MAP HYDRA_NONINTERACTIVE=1
+    echo "dirty-kill missing-session - - - - -" > "$HYDRA_MAP"
+
+    (
+        cd "$repo" || exit 1
+        kill_single_head "dirty-kill" "missing-session" >/dev/null 2>&1
+    )
+    exit_code=$?
+    assert_failure $exit_code "kill_single_head should fail on dirty worktree"
+
+    if grep -q "dirty-kill" "$HYDRA_MAP"; then
+        echo "[PASS] Mapping preserved when kill aborts"
+        pass_count=$((pass_count + 1))
+    else
+        echo "[FAIL] Mapping preserved when kill aborts"
+        fail_count=$((fail_count + 1))
+    fi
+    test_count=$((test_count + 1))
+
+    if [ -d "$wt" ]; then
+        echo "[PASS] Dirty worktree left in place"
+        pass_count=$((pass_count + 1))
+    else
+        echo "[FAIL] Dirty worktree left in place"
+        fail_count=$((fail_count + 1))
+    fi
+    test_count=$((test_count + 1))
+
+    git -C "$repo" worktree remove --force "$wt" 2>/dev/null || rm -rf "$wt"
+    rm -rf "$repo" "$HYDRA_HOME"
+}
+
+test_kill_cleans_messages() {
+    echo ""
+    echo "Testing kill_single_head removes message inbox..."
+
+    test_dir="$(setup_test_env)"
+    HYDRA_HOME="$test_dir"
+    HYDRA_MAP="$test_dir/map"
+    export HYDRA_HOME HYDRA_MAP
+    echo "msg-branch missing-session - - - - -" > "$HYDRA_MAP"
+    mkdir -p "$HYDRA_HOME/messages/msg-branch/queue"
+    echo hi > "$HYDRA_HOME/messages/msg-branch/queue/1"
+
+    kill_single_head "msg-branch" "missing-session" >/dev/null 2>&1
+    assert_success $? "kill_single_head succeeds without a worktree"
+
+    if [ ! -d "$HYDRA_HOME/messages/msg-branch" ]; then
+        echo "[PASS] Message directory removed on kill"
+        pass_count=$((pass_count + 1))
+    else
+        echo "[FAIL] Message directory removed on kill"
+        fail_count=$((fail_count + 1))
+    fi
+    test_count=$((test_count + 1))
+
+    cleanup_test_env "$test_dir"
+}
+
 # =============================================================================
 # Run all tests
 # =============================================================================
@@ -240,6 +318,8 @@ test_kill_all_sessions_empty_map
 test_kill_all_sessions_missing_map
 test_kill_group_sessions_empty_group
 test_kill_group_sessions_nonexistent_group
+test_kill_dirty_worktree_preflight
+test_kill_cleans_messages
 
 echo ""
 echo "================================"

--- a/tests/test_limits.sh
+++ b/tests/test_limits.sh
@@ -335,6 +335,23 @@ test_list_queue_json() {
     cleanup_test_env
 }
 
+test_queue_priority_order() {
+    echo "Testing queue priority-before-time and FIFO..."
+
+    setup_test_env
+
+    queue_spawn "old-low" "claude" "" "default" "10" >/dev/null
+    queue_spawn "high" "claude" "" "default" "90" >/dev/null
+    queue_spawn "new-low" "claude" "" "default" "10" >/dev/null
+
+    order="$(find "$HYDRA_HOME/queue" -maxdepth 1 -name "*.queue" -type f | sort | while IFS= read -r f; do
+        grep '^branch=' "$f" | cut -d= -f2
+    done | tr '\n' ' ')"
+    assert_equal "high old-low new-low " "$order" "high priority before older low; FIFO within priority"
+
+    cleanup_test_env
+}
+
 # =============================================================================
 # Run Tests
 # =============================================================================
@@ -356,6 +373,7 @@ test_dequeue_spawn
 test_clear_queue
 test_list_queue_empty
 test_list_queue_json
+test_queue_priority_order
 
 echo ""
 echo "================================"

--- a/tests/test_locks.sh
+++ b/tests/test_locks.sh
@@ -80,6 +80,21 @@ test_release_lock() {
     assert_success $? "release_lock should succeed for non-existent lock"
 }
 
+test_acquire_lock_fail_closed() {
+    echo "Testing acquire_lock fail-closed..."
+
+    HYDRA_LOCK_RETRIES=1
+    export HYDRA_LOCK_RETRIES
+    try_lock "held"
+    acquire_lock "held"
+    assert_failure $? "acquire_lock should fail when lock is held"
+    release_lock "held"
+    acquire_lock "held"
+    assert_success $? "acquire_lock should succeed when lock is free"
+    release_lock "held"
+    unset HYDRA_LOCK_RETRIES
+}
+
 # Test cleanup_stale_locks function
 test_cleanup_stale_locks() {
     echo "Testing cleanup_stale_locks..."
@@ -146,6 +161,7 @@ echo "================================"
 
 test_try_lock
 test_release_lock
+test_acquire_lock_fail_closed
 test_cleanup_stale_locks
 test_release_session_lock
 test_lock_without_home

--- a/tests/test_maintenance.sh
+++ b/tests/test_maintenance.sh
@@ -20,6 +20,9 @@ HYDRA_LIB_DIR="$(cd "$(dirname "$0")/../lib" && pwd)"
 # shellcheck disable=SC1091
 . "$(dirname "$0")/helpers.sh"
 
+# Stub tmux for maintenance tests
+# shellcheck disable=SC2317
+# shellcheck disable=SC2329
 tmux_session_exists() {
     case "$1" in
         alive-session) return 0 ;;

--- a/tests/test_maintenance.sh
+++ b/tests/test_maintenance.sh
@@ -1,0 +1,129 @@
+#!/bin/sh
+# Unit tests for lib/maintenance.sh
+# POSIX-compliant test framework
+
+test_count=0
+pass_count=0
+fail_count=0
+
+HYDRA_LIB_DIR="$(cd "$(dirname "$0")/../lib" && pwd)"
+# shellcheck disable=SC1091
+. "$HYDRA_LIB_DIR/locks.sh"
+# shellcheck disable=SC1091
+. "$HYDRA_LIB_DIR/tmux.sh"
+# shellcheck disable=SC1091
+. "$HYDRA_LIB_DIR/state.sh"
+# shellcheck disable=SC1091
+. "$HYDRA_LIB_DIR/messages.sh"
+# shellcheck disable=SC1091
+. "$HYDRA_LIB_DIR/maintenance.sh"
+# shellcheck disable=SC1091
+. "$(dirname "$0")/helpers.sh"
+
+tmux_session_exists() {
+    case "$1" in
+        alive-session) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+setup_env() {
+    TEST_DIR="$(mktemp -d)"
+    HYDRA_HOME="$TEST_DIR"
+    HYDRA_MAP="$TEST_DIR/map"
+    export HYDRA_HOME HYDRA_MAP
+    mkdir -p "$HYDRA_HOME/locks"
+    touch "$HYDRA_MAP"
+    _STATE_CACHE_LOADED=""
+}
+
+cleanup_env() {
+    rm -rf "$TEST_DIR"
+}
+
+test_count_stale_locks_mkdir_format() {
+    echo "Testing count_stale_locks with mkdir lock dirs..."
+    setup_env
+
+    mkdir -p "$HYDRA_HOME/locks/fresh.lock"
+    mkdir -p "$HYDRA_HOME/locks/old.lock"
+    touch -t 202001010000 "$HYDRA_HOME/locks/old.lock"
+
+    result="$(count_stale_locks)"
+    assert_equal "1" "$result" "count_stale_locks should see the aged mkdir lock"
+
+    cleaned="$(clean_stale_locks)"
+    assert_equal "1" "$cleaned" "clean_stale_locks should remove the aged mkdir lock"
+
+    if [ -d "$HYDRA_HOME/locks/fresh.lock" ]; then
+        echo "[PASS] Fresh lock directory preserved"
+        pass_count=$((pass_count + 1))
+    else
+        echo "[FAIL] Fresh lock directory preserved"
+        fail_count=$((fail_count + 1))
+    fi
+    test_count=$((test_count + 1))
+
+    if [ ! -d "$HYDRA_HOME/locks/old.lock" ]; then
+        echo "[PASS] Stale mkdir lock removed"
+        pass_count=$((pass_count + 1))
+    else
+        echo "[FAIL] Stale mkdir lock removed"
+        fail_count=$((fail_count + 1))
+    fi
+    test_count=$((test_count + 1))
+
+    cleanup_env
+}
+
+test_clean_dead_mappings_cleans_messages() {
+    echo "Testing clean_dead_mappings removes message dirs..."
+    setup_env
+
+    echo "dead-branch dead-session - - - - -" > "$HYDRA_MAP"
+    echo "live-branch alive-session - - - - -" >> "$HYDRA_MAP"
+    mkdir -p "$HYDRA_HOME/messages/dead-branch/queue"
+    echo "msg" > "$HYDRA_HOME/messages/dead-branch/queue/1"
+    mkdir -p "$HYDRA_HOME/messages/live-branch/queue"
+
+    result="$(clean_dead_mappings)"
+    assert_equal "1" "$result" "One dead mapping removed"
+
+    if [ ! -d "$HYDRA_HOME/messages/dead-branch" ]; then
+        echo "[PASS] Message dir removed for dead mapping"
+        pass_count=$((pass_count + 1))
+    else
+        echo "[FAIL] Message dir removed for dead mapping"
+        fail_count=$((fail_count + 1))
+    fi
+    test_count=$((test_count + 1))
+
+    if grep -q "live-branch" "$HYDRA_MAP"; then
+        echo "[PASS] Live mapping preserved"
+        pass_count=$((pass_count + 1))
+    else
+        echo "[FAIL] Live mapping preserved"
+        fail_count=$((fail_count + 1))
+    fi
+    test_count=$((test_count + 1))
+
+    cleanup_env
+}
+
+echo "Running maintenance.sh unit tests..."
+echo "================================"
+test_count_stale_locks_mkdir_format
+test_clean_dead_mappings_cleans_messages
+echo "================================"
+echo "Test Results:"
+echo "Total:  $test_count"
+echo "Passed: $pass_count"
+echo "Failed: $fail_count"
+
+if [ "$fail_count" -eq 0 ]; then
+    echo "All tests passed!"
+    exit 0
+else
+    echo "Some tests failed!"
+    exit 1
+fi

--- a/tests/test_pane_target.sh
+++ b/tests/test_pane_target.sh
@@ -1,0 +1,81 @@
+#!/bin/sh
+# Pane targeting tests using tests/bin/tmux
+
+test_count=0
+pass_count=0
+fail_count=0
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PATH="$SCRIPT_DIR/bin:$PATH"
+export PATH
+
+HYDRA_LIB_DIR="$(cd "$SCRIPT_DIR/../lib" && pwd)"
+# shellcheck disable=SC1091
+. "$HYDRA_LIB_DIR/tmux.sh"
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/helpers.sh"
+
+test_send_keys_uses_primary_pane() {
+    echo "Testing send_keys_to_session targets :0.0..."
+
+    log="$(mktemp)"
+    HYDRA_TEST_TMUX_LOG="$log"
+    HYDRA_TEST_TMUX_SESSIONS="hydra-feat"
+    export HYDRA_TEST_TMUX_LOG HYDRA_TEST_TMUX_SESSIONS
+
+    send_keys_to_session "hydra-feat" "claude"
+    assert_success $? "send_keys_to_session should succeed against stub"
+
+    if grep -q "send-keys -t hydra-feat:0.0 claude" "$log"; then
+        echo "[PASS] Agent/startup keys go to session:0.0"
+        pass_count=$((pass_count + 1))
+    else
+        echo "[FAIL] Agent/startup keys go to session:0.0"
+        echo "  log: $(cat "$log")"
+        fail_count=$((fail_count + 1))
+    fi
+    test_count=$((test_count + 1))
+    rm -f "$log"
+}
+
+test_find_broadcast_pane_prefers_shell() {
+    echo "Testing find_broadcast_pane skips agent pane..."
+
+    HYDRA_TEST_TMUX_SESSIONS="hydra-feat"
+    HYDRA_TEST_TMUX_PANES="$(printf '%s\t%s\t%s\t%s\t%s\t%s\n%s\t%s\t%s\t%s\t%s\t%s\n' \
+        hydra-feat 0 0 1700000000 claude 0 \
+        hydra-feat 0 1 1700000000 bash 0)"
+    export HYDRA_TEST_TMUX_SESSIONS HYDRA_TEST_TMUX_PANES
+
+    result="$(find_broadcast_pane "hydra-feat" "claude")"
+    assert_equal "hydra-feat:0.1" "$result" "broadcast prefers non-agent shell pane"
+}
+
+test_find_broadcast_pane_refuses_agent_only() {
+    echo "Testing find_broadcast_pane refuses agent-only session..."
+
+    HYDRA_TEST_TMUX_SESSIONS="hydra-feat"
+    HYDRA_TEST_TMUX_PANES="$(printf '%s\t%s\t%s\t%s\t%s\t%s\n' \
+        hydra-feat 0 0 1700000000 claude 0)"
+    export HYDRA_TEST_TMUX_SESSIONS HYDRA_TEST_TMUX_PANES
+
+    find_broadcast_pane "hydra-feat" "claude" >/dev/null 2>&1
+    assert_failure $? "broadcast refuses when only the agent pane exists"
+}
+
+echo "Running pane targeting tests..."
+echo "================================"
+test_send_keys_uses_primary_pane
+test_find_broadcast_pane_prefers_shell
+test_find_broadcast_pane_refuses_agent_only
+echo "================================"
+echo "Total:  $test_count"
+echo "Passed: $pass_count"
+echo "Failed: $fail_count"
+
+if [ "$fail_count" -eq 0 ]; then
+    echo "All tests passed!"
+    exit 0
+fi
+echo "Some tests failed!"
+exit 1

--- a/tests/test_state.sh
+++ b/tests/test_state.sh
@@ -271,6 +271,105 @@ test_without_external_deps() {
     cleanup_test_state "$(dirname "$test_map")"
 }
 
+# Test lock fail-closed and same-filesystem temps
+test_add_mapping_fail_closed() {
+    echo "Testing add_mapping fail-closed on lock contention..."
+
+    test_map="$(setup_test_state)"
+    HYDRA_MAP="$test_map"
+    HYDRA_HOME="$(dirname "$test_map")"
+    HYDRA_LOCK_RETRIES=1
+    export HYDRA_MAP HYDRA_HOME HYDRA_LOCK_RETRIES
+    mkdir -p "$HYDRA_HOME/locks"
+
+    echo "keep-branch keep-session claude g 1 - -" > "$HYDRA_MAP"
+    try_lock "state_map"
+    add_mapping "new-branch" "new-session" 2>/dev/null
+    assert_failure $? "add_mapping should fail when state_map lock is held"
+    if grep -q "new-branch" "$HYDRA_MAP"; then
+        echo "[FAIL] Map must not mutate after lock failure"
+        fail_count=$((fail_count + 1))
+    else
+        echo "[PASS] Map must not mutate after lock failure"
+        pass_count=$((pass_count + 1))
+    fi
+    test_count=$((test_count + 1))
+    release_lock "state_map"
+
+    unset HYDRA_LOCK_RETRIES
+    cleanup_test_state "$(dirname "$test_map")"
+}
+
+test_same_filesystem_temp() {
+    echo "Testing mktemp_adjacent stays next to dest..."
+
+    test_map="$(setup_test_state)"
+    dest_dir="$(dirname "$test_map")"
+    tmp="$(mktemp_adjacent "$test_map")"
+    assert_equal "$dest_dir" "$(dirname "$tmp")" "temp file is on the same directory as dest"
+    rm -f "$tmp"
+    cleanup_test_state "$dest_dir"
+}
+
+test_get_duration_since_invalid() {
+    echo "Testing get_duration_since rejects non-numeric input..."
+
+    result="$(get_duration_since "1700000100 depA,depB 42")"
+    assert_equal "0" "$result" "non-numeric timestamp yields 0 not arithmetic error"
+
+    result="$(get_duration_since "-")"
+    assert_equal "0" "$result" "placeholder timestamp yields 0"
+}
+
+test_state_cache_invalidation() {
+    echo "Testing state cache invalidation after write..."
+
+    test_map="$(setup_test_state)"
+    HYDRA_MAP="$test_map"
+    HYDRA_HOME="$(dirname "$test_map")"
+    export HYDRA_MAP HYDRA_HOME
+    _STATE_CACHE_LOADED=""
+
+    add_mapping "b1" "s1" "claude" "g" "100" "dep" "7"
+    result="$(get_session_for_branch "b1")"
+    assert_equal "s1" "$result" "cache returns session after add"
+
+    add_mapping "b1" "s2" "claude" "g" "100" "dep" "7"
+    result="$(get_session_for_branch "b1")"
+    assert_equal "s2" "$result" "cache invalidates and returns new session"
+
+    result="$(get_group_for_branch "b1")"
+    assert_equal "g" "$result" "group preserved through rewrite"
+    result="$(get_pr_for_branch "b1")"
+    assert_equal "7" "$result" "pr preserved through rewrite"
+
+    cleanup_test_state "$(dirname "$test_map")"
+}
+
+test_regenerate_field_preservation() {
+    echo "Testing regenerate-style metadata preservation..."
+
+    test_map="$(setup_test_state)"
+    HYDRA_MAP="$test_map"
+    HYDRA_HOME="$(dirname "$test_map")"
+    export HYDRA_MAP HYDRA_HOME
+    _STATE_CACHE_LOADED=""
+
+    add_mapping "feat" "old-sess" "aider" "backend" "123456" "dep1,dep2" "99"
+    stored_ai="$(get_ai_for_branch "feat")"
+    stored_group="$(get_group_for_branch "feat")"
+    stored_ts="$(get_timestamp_for_branch "feat")"
+    stored_deps="$(get_deps_for_branch "feat")"
+    stored_pr="$(get_pr_for_branch "feat")"
+    add_mapping "feat" "new-sess" "$stored_ai" "$stored_group" "$stored_ts" "$stored_deps" "$stored_pr"
+
+    line="$(grep "^feat " "$HYDRA_MAP")"
+    expected="feat new-sess aider backend 123456 dep1,dep2 99"
+    assert_equal "$expected" "$line" "regenerate rewrite preserves metadata except session"
+
+    cleanup_test_state "$(dirname "$test_map")"
+}
+
 # Run all tests
 echo "Running state.sh unit tests..."
 echo "================================"
@@ -283,6 +382,11 @@ test_get_branch_for_session
 test_list_mappings
 test_generate_session_name
 test_without_external_deps
+test_add_mapping_fail_closed
+test_same_filesystem_temp
+test_get_duration_since_invalid
+test_state_cache_invalidation
+test_regenerate_field_preservation
 
 echo "================================"
 echo "Test Results:"

--- a/tests/test_tui.sh
+++ b/tests/test_tui.sh
@@ -174,8 +174,11 @@ test_tui_row_contract() {
     TUI_SELECTED=0
     TUI_OFFSET=0
     TUI_ROWS=24
+    # shellcheck disable=SC2034
     TUI_ACTIVITY_DIR=""
+    # shellcheck disable=SC2034
     TUI_SEARCH_PATTERN=""
+    # shellcheck disable=SC2034
     TUI_TAG_FILTER=""
     tui_init_tags
     tui_build_list

--- a/tests/test_tui.sh
+++ b/tests/test_tui.sh
@@ -159,6 +159,38 @@ test_tui_build_list() {
     rm -rf "$TEST_HOME"
 }
 
+test_tui_row_contract() {
+    TESTS_RUN=$((TESTS_RUN + 1))
+
+    TEST_HOME="$(mktemp -d)"
+    HYDRA_HOME="$TEST_HOME"
+    HYDRA_MAP="$HYDRA_HOME/map"
+    mkdir -p "$HYDRA_HOME"
+    echo "b1 s1 claude grp 111 d1 9" > "$HYDRA_MAP"
+
+    source_libs
+    TUI_TEMP_LIST="$(mktemp)"
+    TUI_ITEM_COUNT=0
+    TUI_SELECTED=0
+    TUI_OFFSET=0
+    TUI_ROWS=24
+    TUI_ACTIVITY_DIR=""
+    TUI_SEARCH_PATTERN=""
+    TUI_TAG_FILTER=""
+    tui_init_tags
+    tui_build_list
+
+    fields="$(awk -F '	' 'NF { print NF; exit }' "$TUI_TEMP_LIST")"
+    if [ "$fields" = "8" ]; then
+        print_pass "TUI list rows have 8 tab-separated fields"
+    else
+        print_fail "TUI list rows should have 8 fields, got $fields ($(cat "$TUI_TEMP_LIST"))"
+    fi
+
+    rm -f "$TUI_TEMP_LIST"
+    rm -rf "$TEST_HOME"
+}
+
 # Test: Selection bounds checking
 test_tui_selection_bounds() {
     TESTS_RUN=$((TESTS_RUN + 1))
@@ -396,6 +428,7 @@ main() {
     test_tput_check
     test_tui_init_colors
     test_tui_build_list
+    test_tui_row_contract
     test_tui_selection_bounds
     test_tui_empty_list
     test_tui_key_quit


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Hydra 1.5.1 makes the shipped POSIX shell CLI a trustworthy baseline (roadmap §4.2 / §8.1). No state migration.

This PR supersedes #58. That branch is ruleset-locked after the first push (`GH013`: changes must be made through a pull request), so the ShellCheck and phantom-session kill-message follow-up could not be pushed there. This branch includes both stacked commits:

1. Core 1.5.1 hardening
2. Restore the historic `Session '…' not found, cleaning up mapping...` line for `kill --all`, and ShellCheck disables for the tmux stub / unused TUI globals

## Fixes
- Shared `state_map` lock; writers fail closed instead of unlocked fallback writes
- Same-filesystem temp + `mv` for map, tags, and maintenance rewrites
- Doctor/cleanup stale locks match empty `mkdir` `*.lock` directories
- `hydra status` reads all seven map fields and rejects non-numeric durations
- Kill preflights dirty worktrees before tmux/mapping teardown; message inboxes are removed on kill and dead-mapping cleanup
- `hydra regenerate` preserves group, deps, PR, and timestamp
- Queue sorts high priority first, FIFO within a priority
- `json_escape` covers C0 controls (`\n` `\r` `\b` `\f` `\u00XX`)
- Startup/agent launch always target `session:0.0`; broadcast prefers a non-agent shell pane (`--pane` / `--force`)
- TUI readers consume the 8-field tab row contract
- Completions cover every dispatched command
- `.gitignore` newline fix; stop tracking `.hydra/map`

## Docs / tooling
- `docs/CONTRACTS.md` records the 1.5 public surface
- README supported-platform statement
- `make bench` records list/status/doctor/TUI timings (measurements only)
- Version bump to 1.5.1

## Test plan
- `make lint` and `make test` (dash)
- New suites: `test_maintenance.sh`, `test_pane_target.sh`
- Extended tests for locks, state, kill, JSON, queue order, completion, TUI rows, status JSON

Out of scope: 1.5.2 onboarding, state v2, C. Tag `v1.5.1` after merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a036bf-b9a8-782d-a434-5a687db9f4dc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a036bf-b9a8-782d-a434-5a687db9f4dc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

