### PR TITLE
1.5.2: Frictionless first run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.2] - 2026-08-26
+
+### Added
+- Non-root `PREFIX` install: `$PREFIX/bin/hydra` and `$PREFIX/lib/hydra` (`install.sh` and `make install`)
+- Matching `uninstall.sh` / `make uninstall` for the same prefix; optional `DESTDIR` staging
+- Install verification runs `hydra version` and prints exact binary and library paths
+- `hydra doctor` reports install layout, git/tmux versions, writable `HYDRA_HOME`, repo/worktree readiness, detected agents, and a `Next:` recovery for every failure
+- Fresh-prefix `make test-install` and throwaway-repo `make smoke-onboarding` tests
+- README five-minute Quick Start (run-from-source or prefix install, `HYDRA_SKIP_AI=1`, completions)
+
+### Changed
+- Library discovery: `HYDRA_ROOT`, source `../lib`, PREFIX `../lib/hydra`, then legacy `/usr/local/lib/hydra`
+- First-run errors name the failed precondition and the next command or doc action
+- Spawn fails if the selected agent is not on `PATH` unless `HYDRA_SKIP_AI=1`
+
+### Fixed
+- Installer and Make no longer require root or hard-code `/usr/local` as the only layout
+
 ## [1.5.1] - 2026-08-25
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
 # Makefile for Hydra
 # POSIX-compliant build and lint tasks
 
-.PHONY: all lint test clean install dev-setup bench help
+.PHONY: all lint test clean install uninstall test-install smoke-onboarding dev-setup bench help
+
+# Installation prefix (no root required when writable)
+PREFIX ?= /usr/local
+DESTDIR ?=
 
 # Default target
 all: lint
@@ -42,16 +46,22 @@ clean:
 	@find . -name "*~" -o -name "*.swp" -o -name ".*.swp" | xargs rm -f
 	@echo "Clean complete"
 
-# Install hydra to /usr/local/bin
+# Install hydra to $(PREFIX)/bin and $(PREFIX)/lib/hydra
+# Same layout and verification as ./install.sh
 install:
-	@echo "Installing hydra..."
-	@mkdir -p /usr/local/bin
-	@cp bin/hydra /usr/local/bin/hydra
-	@chmod +x /usr/local/bin/hydra
-	@mkdir -p /usr/local/lib/hydra
-	@cp lib/*.sh /usr/local/lib/hydra/
-	@echo "Installation complete"
-	@echo "Run 'hydra help' to get started"
+	PREFIX="$(PREFIX)" DESTDIR="$(DESTDIR)" sh ./install.sh
+
+# Remove files installed to $(PREFIX)
+uninstall:
+	PREFIX="$(PREFIX)" DESTDIR="$(DESTDIR)" sh ./uninstall.sh
+
+# Fresh-prefix install, verify, and uninstall
+test-install:
+	@sh tests/test_install.sh
+
+# Throwaway-repository, no-agent first-head path
+smoke-onboarding:
+	@sh tests/test_onboarding.sh
 
 # Set up development environment
 dev-setup:
@@ -70,6 +80,9 @@ help:
 	@echo "  make test      - Run all tests"
 	@echo "  make bench     - Record list/status/doctor/TUI timings at 5 and 20 heads"
 	@echo "  make clean     - Remove temporary files"
-	@echo "  make install   - Install hydra to /usr/local/bin"
+	@echo "  make install   - Install hydra to \$$PREFIX/bin (default /usr/local)"
+	@echo "  make uninstall - Remove hydra from \$$PREFIX"
+	@echo "  make test-install - Fresh-prefix install/uninstall tests"
+	@echo "  make smoke-onboarding - Throwaway-repo no-agent first-head smoke"
 	@echo "  make dev-setup - Set up development environment (git hooks)"
 	@echo "  make help      - Show this help message"

--- a/README.md
+++ b/README.md
@@ -31,15 +31,80 @@
 
 ## Quick Start
 
+Five-minute tour: install or run from source, verify, create a disposable head, then clean it up. No root and no agent CLI required.
+
 - Requirements: `git`, `tmux` (≥ 3.0). Optional: `fzf`, GitHub CLI, an AI CLI (`claude`, `aider`, `gemini`, etc.).
 - Supported platforms: Linux and macOS; POSIX `sh` (dash on Debian/Ubuntu); `tmux >= 3.0` and `git`. CI runs Ubuntu and macOS. Windows is not supported.
-- Public CLI, map, JSON, lock, and TUI-row contracts: [docs/CONTRACTS.md](docs/CONTRACTS.md).
-- Install:
-  - `git clone https://github.com/Someblueman/hydra && cd hydra && sudo ./install.sh`
-  - or `sudo make install`
-- Try it:
-  - `hydra spawn feature-x -l dev`
-  - `hydra list` • `hydra switch` • `hydra dashboard` • `hydra kill feature-x`
+- Public CLI, map, JSON, lock, install, and TUI-row contracts: [docs/CONTRACTS.md](docs/CONTRACTS.md).
+
+### 1. Install (or run from source)
+
+Non-root install to a writable prefix:
+
+```sh
+git clone https://github.com/Someblueman/hydra && cd hydra
+PREFIX=$HOME/.local ./install.sh
+# or: make install PREFIX=$HOME/.local
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+`sudo ./install.sh` and `sudo make install` still install to `/usr/local` (the default `PREFIX`).
+
+Or skip install and run from the checkout:
+
+```sh
+git clone https://github.com/Someblueman/hydra && cd hydra
+./bin/hydra version
+# If you invoke the binary from elsewhere: export HYDRA_ROOT=/path/to/hydra
+```
+
+### 2. Verify
+
+```sh
+hydra version          # Hydra version 1.5.2
+hydra doctor           # install paths, git/tmux, writable HYDRA_HOME, agents
+```
+
+### 3. Create a throwaway first head
+
+Use a disposable repository so Hydra does not create branches in a real project. No agent CLI is required:
+
+```sh
+mkdir /tmp/hydra-tour && cd /tmp/hydra-tour
+git init && git commit --allow-empty -m "tour"
+export HYDRA_SKIP_AI=1
+hydra spawn first-head
+hydra list
+hydra switch           # enter the session (fzf if installed)
+```
+
+`HYDRA_SKIP_AI=1` is the supported shell-only path. Spawn defaults to `claude` only when that variable is unset; if the agent is missing, Hydra names the recovery (`HYDRA_SKIP_AI=1` or install the agent).
+
+### 4. Clean up
+
+```sh
+hydra kill first-head
+hydra list             # empty
+```
+
+That leaves no Hydra tmux session, worktree, branch, or `HYDRA_HOME` map entry for `first-head`.
+
+### Shell completions
+
+Write completions into your user files (no root):
+
+```sh
+# bash
+hydra completion bash >> ~/.bashrc
+
+# zsh (ensure the directory is on fpath)
+mkdir -p ~/.zsh/completions
+hydra completion zsh > ~/.zsh/completions/_hydra
+
+# fish
+mkdir -p ~/.config/fish/completions
+hydra completion fish > ~/.config/fish/completions/hydra.fish
+```
 
 ## Demo
 
@@ -88,7 +153,7 @@ hydra wait-idle -g backend -s 10 # wait for group with 10s idle threshold
 hydra regenerate   # restore sessions after restart
 hydra status       # per-head health
 hydra status --json # JSON output
-hydra doctor       # performance diagnostics
+hydra doctor       # install, dependencies, and first-run readiness
 
 # Dashboard & TUI
 hydra dashboard                                    # multi-session overview
@@ -199,10 +264,15 @@ make help    # Show all targets
 
 ## Uninstall
 
+Use the same `PREFIX` you installed with:
+
 ```sh
-sudo ./uninstall.sh            # prompts to remove user data
-sudo ./uninstall.sh --purge    # non-interactive, remove user data
+PREFIX=$HOME/.local ./uninstall.sh            # prompts to remove user data
+PREFIX=$HOME/.local ./uninstall.sh --purge    # non-interactive, remove user data
+# or: make uninstall PREFIX=$HOME/.local
 ```
+
+Default `PREFIX` is `/usr/local` (may need `sudo` if you installed there).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -54,8 +54,9 @@ Or skip install and run from the checkout:
 
 ```sh
 git clone https://github.com/Someblueman/hydra && cd hydra
-./bin/hydra version
-# If you invoke the binary from elsewhere: export HYDRA_ROOT=/path/to/hydra
+export HYDRA_ROOT="$PWD"
+export PATH="$HYDRA_ROOT/bin:$PATH"
+hydra version
 ```
 
 ### 2. Verify
@@ -84,6 +85,7 @@ hydra switch           # enter the session (fzf if installed)
 
 ```sh
 hydra kill first-head
+git branch -D first-head # remove the disposable tour branch
 hydra list             # empty
 ```
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,51 +1,48 @@
-# Hydra v1.5.1 Release Notes
+# Hydra v1.5.2 Release Notes
 
-**Release date:** 2026-08-25
+**Release date:** 2026-08-26
 
 ## Highlights
 
-Hydra 1.5.1 hardens the shipped POSIX shell CLI so it is a trustworthy baseline:
-locking and atomic file replace, kill/regenerate/queue/JSON correctness, explicit
-tmux pane targets, and a documented 1.5 public contract. No state migration is
-required.
+Hydra 1.5.2 is a five-minute, agent-optional first run. A clean macOS or Linux
+user can install to a writable prefix without `sudo`, verify the install, create
+a disposable head in a throwaway repository, and clean it up — with or without
+an AI CLI.
 
-## Correctness
+## Install and discovery
 
-- Map writers share one lock and no longer write if acquisition fails
-- Temp files for map/tags rewrites stay on the same filesystem as the destination
-- `hydra status` reads all seven map fields and validates duration timestamps
-- `hydra kill` checks dirty worktrees before killing tmux or dropping the mapping
-- Message inboxes are deleted on kill and dead-mapping cleanup
-- Doctor/cleanup stale locks match the `mkdir` `*.lock` directory format
-- `hydra regenerate` keeps group, dependency, PR, and timestamp metadata
-- Spawn queue processes high priority first, FIFO within one priority
-- JSON strings escape every C0 control character
+- `PREFIX=$HOME/.local ./install.sh` (or `make install PREFIX=$HOME/.local`)
+- Layout: `$PREFIX/bin/hydra` and `$PREFIX/lib/hydra`
+- `install.sh` and `make install` share one contract, run `hydra version`, and
+  print the exact binary and library paths
+- Matching uninstall for the same `PREFIX`; `DESTDIR` staging is supported
+- Run-from-source remains a supported evaluation path (`./bin/hydra`)
+- Library discovery: `HYDRA_ROOT`, source `../lib`, PREFIX `../lib/hydra`,
+  legacy `/usr/local/lib/hydra`
 
-## tmux and TUI
+## First-run readiness
 
-- Startup and agent launch target `session:0.0`
-- `hydra broadcast` prefers a non-agent shell pane; refuses agent-only sessions unless `--force` or `--pane`
-- TUI rows are eight tab-separated fields end to end
-- List/status/TUI refresh batch tmux session and pane observations (`window_activity` first)
-
-## Docs and tooling
-
-- [docs/CONTRACTS.md](docs/CONTRACTS.md) records the 1.5 public surface
-- README states supported platforms
-- `make bench` records shell timings (measurements only)
-- Completions include `group`, `send`, `recv`, `tail`, `broadcast`, `wait-idle`, `queue`
+- `hydra doctor` reports install layout, git/tmux versions, writable
+  `HYDRA_HOME`, repository/worktree readiness, and detected agent CLIs
+- Every doctor and onboarding failure includes a `Next:` recovery action
+- Spawn without an agent on `PATH` fails closed and points at `HYDRA_SKIP_AI=1`
+- README Quick Start is a replayable throwaway-repo tour with user-level
+  shell completion install
 
 ## Upgrade
 
 ```sh
-sudo ./install.sh   # or: sudo make install
-hydra version       # should show 1.5.1
+git pull
+PREFIX=$HOME/.local ./install.sh   # or: make install PREFIX=$HOME/.local
+hydra version                      # should show 1.5.2
+hydra doctor
 ```
 
-No migration steps required for `~/.hydra` state files. Non-root `PREFIX`
-install remains a 1.5.2 item.
+No migration steps required for `~/.hydra` state files. Default `PREFIX` is
+still `/usr/local` if you prefer `sudo ./install.sh`.
 
 ## Test Coverage
 
-Run `make lint` and `make test`. Passing runs may still print `Error: ...`
-lines from expected error-path assertions.
+Run `make lint` and `make test`. Dedicated gates: `make test-install` and
+`make smoke-onboarding`. Passing runs may still print `Error: ...` lines from
+expected error-path assertions.

--- a/bin/hydra
+++ b/bin/hydra
@@ -11,7 +11,7 @@ if [ -z "${HOME:-}" ] || [ ! -d "${HOME:-}" ]; then
 fi
 HYDRA_HOME="${HYDRA_HOME:-$HOME/.hydra}"
 HYDRA_MAP="$HYDRA_HOME/map"
-HYDRA_VERSION="1.5.1"
+HYDRA_VERSION="1.5.2"
 
 # Source helper libraries
 # Enhanced library detection with multiple fallback paths
@@ -33,24 +33,28 @@ else
     HYDRA_BIN_DIR="$(dirname "$HYDRA_BIN_PATH")"
 fi
 
-# Try multiple paths to find the library directory
-if [ -d "$HYDRA_BIN_DIR/../lib" ] && [ -f "$HYDRA_BIN_DIR/../lib/git.sh" ]; then
-    # Running from source - resolve to absolute path
+# Library discovery (1.5.2): HYDRA_ROOT, source ../lib, PREFIX ../lib/hydra, legacy
+if [ -n "${HYDRA_ROOT:-}" ] && [ -d "$HYDRA_ROOT/lib" ] && [ -f "$HYDRA_ROOT/lib/git.sh" ]; then
+    HYDRA_LIB_DIR="$(cd "$HYDRA_ROOT/lib" && pwd)"
+elif [ -d "$HYDRA_BIN_DIR/../lib" ] && [ -f "$HYDRA_BIN_DIR/../lib/git.sh" ]; then
+    # Running from a source checkout: bin/../lib
     HYDRA_LIB_DIR="$(cd "$HYDRA_BIN_DIR/../lib" && pwd)"
+elif [ -d "$HYDRA_BIN_DIR/../lib/hydra" ] && [ -f "$HYDRA_BIN_DIR/../lib/hydra/git.sh" ]; then
+    # PREFIX install: $PREFIX/bin/hydra -> $PREFIX/lib/hydra
+    HYDRA_LIB_DIR="$(cd "$HYDRA_BIN_DIR/../lib/hydra" && pwd)"
 elif [ -d "/usr/local/lib/hydra" ] && [ -f "/usr/local/lib/hydra/git.sh" ]; then
-    # Installed location
+    # Legacy default prefix
     HYDRA_LIB_DIR="/usr/local/lib/hydra"
-elif [ -n "${HYDRA_ROOT:-}" ] && [ -d "$HYDRA_ROOT/lib" ] && [ -f "$HYDRA_ROOT/lib/git.sh" ]; then
-    # Environment variable override
-    HYDRA_LIB_DIR="$HYDRA_ROOT/lib"
 else
     echo "Error: Cannot find hydra library directory" >&2
+    echo "Precondition: libraries must resolve from the binary (source ../lib or PREFIX ../lib/hydra)." >&2
     echo "Searched in:" >&2
-    echo "  - $HYDRA_BIN_DIR/../lib (source)" >&2
-    echo "  - /usr/local/lib/hydra (installed)" >&2
     [ -n "${HYDRA_ROOT:-}" ] && echo "  - $HYDRA_ROOT/lib (HYDRA_ROOT)" >&2
-    echo "" >&2
-    echo "Please ensure hydra is properly installed or set HYDRA_ROOT environment variable" >&2
+    echo "  - $HYDRA_BIN_DIR/../lib (source checkout)" >&2
+    echo "  - $HYDRA_BIN_DIR/../lib/hydra (PREFIX install)" >&2
+    echo "  - /usr/local/lib/hydra (legacy)" >&2
+    echo "Next: run bin/hydra from a source checkout, set HYDRA_ROOT to that checkout, or reinstall with PREFIX=\$HOME/.local ./install.sh" >&2
+    echo "See README Quick Start." >&2
     exit 1
 fi
 
@@ -226,17 +230,29 @@ _load_libs_for_cmd() {
 
 # Export paths for downstream helpers (e.g., safe tmux run-shell bindings)
 export HYDRA_LIB_DIR
+export HYDRA_BIN_DIR
 # Resolve the absolute path to the current hydra binary for secure bindings
 HYDRA_BIN_CMD="${HYDRA_BIN_PATH}"
 export HYDRA_BIN_CMD
 
 # Initialize Hydra home directory
 init_hydra_home() {
-    if [ ! -d "$HYDRA_HOME" ]; then
-        mkdir -p "$HYDRA_HOME"
+    if ! mkdir -p "$HYDRA_HOME" 2>/dev/null; then
+        echo "Error: HYDRA_HOME is not writable: $HYDRA_HOME" >&2
+        echo "Next: export HYDRA_HOME=\"\$HOME/.hydra\" and ensure that directory is writable, or see README Quick Start" >&2
+        exit 1
+    fi
+    if [ ! -w "$HYDRA_HOME" ]; then
+        echo "Error: HYDRA_HOME is not writable: $HYDRA_HOME" >&2
+        echo "Next: chmod u+w \"$HYDRA_HOME\" or export HYDRA_HOME to a writable directory (see README Quick Start)" >&2
+        exit 1
     fi
     if [ ! -f "$HYDRA_MAP" ]; then
-        touch "$HYDRA_MAP"
+        if ! touch "$HYDRA_MAP" 2>/dev/null; then
+            echo "Error: Cannot create state map at $HYDRA_MAP" >&2
+            echo "Next: ensure HYDRA_HOME is writable (export HYDRA_HOME=\"\$HOME/.hydra\")" >&2
+            exit 1
+        fi
     fi
 }
 
@@ -311,7 +327,7 @@ Commands:
   status            Show health status of all heads
                     Options:
                       -j, --json               Output in JSON format
-  doctor            Check system health and consistency
+  doctor            Check install, dependencies, and first-run readiness
                     Options:
                       -f, --fix                Auto-fix detected issues
   cleanup           Remove dead mappings, stale locks, and orphaned worktrees
@@ -358,6 +374,7 @@ Examples:
 Environment:
   HYDRA_HOME        Directory for runtime files (default: ~/.hydra)
   HYDRA_AI_COMMAND  Default AI tool (default: claude)
+  HYDRA_SKIP_AI     Set to 1 to spawn a shell-only head (no agent CLI)
   HYDRA_ROOT        Override hydra installation path (for library discovery)
   HYDRA_DASHBOARD_PANES_PER_SESSION  Panes per session for dashboard (1, N, or all)
   HYDRA_MAX_SESSIONS  Maximum active sessions (default: unlimited)

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -1,6 +1,6 @@
 # Hydra 1.5 public contracts
 
-This document records which 1.5.0 behaviors remain public through 1.5.1.
+This document records which 1.5.0 behaviors remain public through 1.5.2.
 Internal function names, the in-process state cache, and TUI render details
 are not contracts.
 
@@ -81,7 +81,32 @@ Documented in the README: `HYDRA_HOME`, `HYDRA_ROOT`, `HYDRA_AI_COMMAND`,
 `HYDRA_SKIP_AI`, `HYDRA_NONINTERACTIVE`, and the other `HYDRA_*` variables
 listed there.
 
+## Installation
+
+Default prefix is `/usr/local`. Layout:
+
+```text
+$PREFIX/bin/hydra
+$PREFIX/lib/hydra/*.sh
+```
+
+`DESTDIR`, when set, is prepended to those paths (staged `make install`).
+Root is not required when `PREFIX` is writable. `install.sh` and `make install`
+produce the same layout and verification output: they run the installed
+`hydra version` and print the exact binary and library paths.
+
+Library discovery order:
+
+1. `$HYDRA_ROOT/lib` when `HYDRA_ROOT` is set and contains `git.sh`
+2. `$HYDRA_BIN_DIR/../lib` (run from a source checkout)
+3. `$HYDRA_BIN_DIR/../lib/hydra` (`PREFIX` install)
+4. `/usr/local/lib/hydra` (legacy fallback)
+
+Uninstall uses the same `PREFIX`/`DESTDIR` and removes only those installed
+files. `--purge` may remove `HYDRA_HOME` / `~/.hydra`; it never touches the
+source repository.
+
 ## Not covered
 
-State v2, instance IDs, events, native helpers, and non-root `PREFIX` install
-are later releases. Pre-2.0 internal library layout may change.
+State v2, instance IDs, events, and native helpers are later releases.
+Pre-2.0 internal library layout may change.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -597,24 +597,24 @@ experience without introducing new lifecycle architecture.
 
 #### Scope
 
-- [ ] Support installation to a writable `PREFIX` without root, with a matching
+- [x] Support installation to a writable `PREFIX` without root, with a matching
       uninstall path and equivalent behavior from `install.sh` and `make install`.
-- [ ] Document running directly from a source checkout as a supported evaluation
+- [x] Document running directly from a source checkout as a supported evaluation
       path that does not require installation.
-- [ ] Verify installation by running `hydra version`, confirming library discovery,
+- [x] Verify installation by running `hydra version`, confirming library discovery,
       and reporting the exact installed paths.
-- [ ] Expand `hydra doctor` to report Git and tmux versions, writable `HYDRA_HOME`,
+- [x] Expand `hydra doctor` to report Git and tmux versions, writable `HYDRA_HOME`,
       install/library consistency, repository and worktree readiness, detected agent
       CLIs, and a concrete remediation for every failure.
-- [ ] Replace the Quick Start with a replayable five-minute tour: install or run from
+- [x] Replace the Quick Start with a replayable five-minute tour: install or run from
       source, verify, create a disposable first head in a throwaway repository, list
       and enter it, then kill it and verify cleanup.
-- [ ] Make the existing shell-only path obvious for users with no agent installed,
+- [x] Make the existing shell-only path obvious for users with no agent installed,
       including the current `HYDRA_SKIP_AI=1` behavior.
-- [ ] Add shell-completion installation instructions for supported shells.
-- [ ] Rewrite first-run errors to name the failed precondition and the next command
+- [x] Add shell-completion installation instructions for supported shells.
+- [x] Rewrite first-run errors to name the failed precondition and the next command
       or documentation action the user should take.
-- [ ] Add fresh-home, fresh-prefix install/uninstall tests and a throwaway-repository
+- [x] Add fresh-home, fresh-prefix install/uninstall tests and a throwaway-repository
       onboarding smoke test that cannot create branches or worktrees in Hydra's own
       source repository.
 
@@ -1198,7 +1198,7 @@ recorded architecture decisions.
 
 | Decision | Blocks | Resolution evidence | Status |
 | --- | --- | --- | --- |
-| Installation prefix, layout, and version discovery | 1.5.2 onboarding | Fresh-prefix install/uninstall on macOS and Linux plus run-from-source parity | Open |
+| Installation prefix, layout, and version discovery | 1.5.2 onboarding | Fresh-prefix install/uninstall plus run-from-source parity | Accepted: `$PREFIX/bin` + `$PREFIX/lib/hydra`; relative discovery; `HYDRA_ROOT` first |
 | Default agent detection and no-agent selection | 1.6 guided onboarding | Clean-home fixtures with zero, one, and multiple detected agent CLIs | Open |
 | Project identity generation | State v2 | Collision, repo move, clone, and duplicate-branch fixtures | Open |
 | Physical state v2 representation | Migration and native reader | Shell simplicity, atomicity, malformed-input fixtures | Open |
@@ -1228,11 +1228,13 @@ These are bounded design gates, not permission for open-ended architecture work.
 ### Next: remove first-run friction
 
 1. Support non-root `PREFIX` installation, matching uninstall, and verified
-   run-from-source behavior.
+   run-from-source behavior. **Done in 1.5.2.**
 2. Expand `hydra doctor` into an actionable installation and readiness check.
+   **Done in 1.5.2.**
 3. Publish the five-minute throwaway-repository Quick Start with an obvious
-   no-agent path and shell-completion setup.
+   no-agent path and shell-completion setup. **Done in 1.5.2.**
 4. Protect that path with fresh-home install and onboarding smoke tests.
+   **Done in 1.5.2.**
 
 ### After that: ship the shell lifecycle foundation
 

--- a/install.sh
+++ b/install.sh
@@ -1,45 +1,88 @@
+#!/bin/sh
 # POSIX-compliant installation script
+# Installs to $PREFIX/bin/hydra and $PREFIX/lib/hydra (default PREFIX=/usr/local).
+# No root required when PREFIX is writable. DESTDIR is optional staging.
 
 set -e
 
-# Check for root permissions
-if [ "$(id -u)" -ne 0 ]; then
-    echo "This script requires root permissions. Please run with sudo." >&2
+usage() {
+    echo "Usage: [PREFIX=/usr/local] [DESTDIR=] ./install.sh" >&2
+    echo "  PREFIX    installation prefix (default: /usr/local)" >&2
+    echo "  DESTDIR   optional staging directory prepended to PREFIX" >&2
+    echo "" >&2
+    echo "Non-root example:" >&2
+    echo "  PREFIX=\$HOME/.local ./install.sh" >&2
+    echo "See README Quick Start." >&2
+}
+
+if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+    usage
+    exit 0
+fi
+
+if [ $# -gt 0 ]; then
+    echo "Error: Unexpected argument '$1'" >&2
+    echo "Next: pass PREFIX and DESTDIR as environment variables, not flags" >&2
+    usage
     exit 1
 fi
 
-echo "Installing hydra..."
+SCRIPT_DIR="$(CDPATH= cd "$(dirname "$0")" && pwd)"
+SRC_BIN="$SCRIPT_DIR/bin/hydra"
+SRC_LIB="$SCRIPT_DIR/lib"
 
-# Installation directories
-BIN_DIR="/usr/local/bin"
-LIB_DIR="/usr/local/lib/hydra"
+PREFIX="${PREFIX:-/usr/local}"
+DESTDIR="${DESTDIR:-}"
 
-# Verify we're in the hydra project directory
-if [ ! -f "bin/hydra" ] || [ ! -d "lib" ]; then
-    echo "Error: This script must be run from the hydra project directory" >&2
-    echo "Please cd to the hydra directory and run: sudo ./install.sh" >&2
+case "$PREFIX" in
+    /*) ;;
+    *)
+        PREFIX="$(pwd)/$PREFIX"
+        ;;
+esac
+
+BIN_DIR="${DESTDIR}${PREFIX}/bin"
+LIB_DIR="${DESTDIR}${PREFIX}/lib/hydra"
+
+if [ ! -f "$SRC_BIN" ] || [ ! -d "$SRC_LIB" ]; then
+    echo "Error: This script must be run from a hydra source checkout" >&2
+    echo "Precondition: bin/hydra and lib/ must exist next to install.sh" >&2
+    echo "Next: cd to the hydra directory and run: PREFIX=\$HOME/.local ./install.sh" >&2
     exit 1
 fi
 
-# Additional safety check - verify it's actually hydra
-if ! grep -q "Hydra - POSIX-compliant CLI" bin/hydra 2>/dev/null; then
-    echo "Error: bin/hydra does not appear to be the correct hydra binary" >&2
+if ! grep -q "Hydra - POSIX-compliant CLI" "$SRC_BIN" 2>/dev/null; then
+    echo "Error: bin/hydra does not appear to be the hydra binary" >&2
+    echo "Next: cd to the hydra source checkout and retry ./install.sh" >&2
     exit 1
 fi
 
-# Create directories if they don't exist
-echo "Creating installation directories..."
-mkdir -p "$BIN_DIR"
-mkdir -p "$LIB_DIR"
+ensure_writable() {
+    target="$1"
+    if [ -d "$target" ]; then
+        if [ -w "$target" ]; then
+            return 0
+        fi
+    elif mkdir -p "$target" 2>/dev/null; then
+        return 0
+    fi
+    echo "Error: PREFIX is not writable: $target" >&2
+    echo "Next: PREFIX=\$HOME/.local $0   or   sudo env PREFIX=$PREFIX $0" >&2
+    echo "See README Quick Start." >&2
+    return 1
+}
 
-# Install the main binary
+echo "Installing hydra to $PREFIX..."
+
+ensure_writable "$BIN_DIR"
+ensure_writable "$LIB_DIR"
+
 echo "Installing hydra binary..."
-cp bin/hydra "$BIN_DIR/hydra"
+cp "$SRC_BIN" "$BIN_DIR/hydra"
 chmod +x "$BIN_DIR/hydra"
 
-# Install library files
 echo "Installing library files..."
-for lib_file in lib/*.sh; do
+for lib_file in "$SRC_LIB"/*.sh; do
     if [ -f "$lib_file" ]; then
         filename="$(basename "$lib_file")"
         echo "  Installing $filename..."
@@ -47,24 +90,44 @@ for lib_file in lib/*.sh; do
     fi
 done
 
-# Verify installation
-if [ -x "$BIN_DIR/hydra" ]; then
-    echo ""
-    echo "Installation complete!"
-    echo ""
-    echo "Hydra has been installed to $BIN_DIR/hydra"
-    echo "Library files installed to $LIB_DIR/"
-    echo ""
-    echo "Run 'hydra help' to get started"
-    echo ""
-    
-    # Check if /usr/local/bin is in PATH
-    if ! echo "$PATH" | grep -q "/usr/local/bin"; then
-        echo "WARNING: /usr/local/bin is not in your PATH"
-        echo "You may need to add it to your shell configuration:"
-        echo "  export PATH=\"/usr/local/bin:\$PATH\""
-    fi
-else
-    echo "Error: Installation failed" >&2
+if [ ! -x "$BIN_DIR/hydra" ]; then
+    echo "Error: Installation failed: $BIN_DIR/hydra is not executable" >&2
+    echo "Next: PREFIX=\$HOME/.local $0 or see README Quick Start" >&2
     exit 1
 fi
+
+if [ ! -f "$LIB_DIR/git.sh" ]; then
+    echo "Error: Installation failed: libraries missing at $LIB_DIR" >&2
+    echo "Next: re-run from a complete source checkout (lib/*.sh must exist)" >&2
+    exit 1
+fi
+
+# Confirm library discovery without a HYDRA_ROOT override
+ver_out="$(
+    unset HYDRA_ROOT
+    "$BIN_DIR/hydra" version
+)" || {
+    echo "Error: Installed hydra could not run (library discovery failed)" >&2
+    echo "Next: confirm $LIB_DIR/git.sh exists, or set HYDRA_ROOT and see README Quick Start" >&2
+    exit 1
+}
+
+echo ""
+echo "Installation complete!"
+echo ""
+echo "$ver_out"
+echo "Binary: $BIN_DIR/hydra"
+echo "Libraries: $LIB_DIR"
+echo ""
+echo "Run 'hydra doctor' to verify readiness, or see README Quick Start."
+echo ""
+
+case ":$PATH:" in
+    *":$PREFIX/bin:"*)
+        ;;
+    *)
+        echo "WARNING: $PREFIX/bin is not in your PATH"
+        echo "Next: add it to your shell configuration:"
+        echo "  export PATH=\"$PREFIX/bin:\$PATH\""
+        ;;
+esac

--- a/install.sh
+++ b/install.sh
@@ -27,7 +27,7 @@ if [ $# -gt 0 ]; then
     exit 1
 fi
 
-SCRIPT_DIR="$(CDPATH= cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SRC_BIN="$SCRIPT_DIR/bin/hydra"
 SRC_LIB="$SCRIPT_DIR/lib"
 

--- a/lib/cmd_maintenance.sh
+++ b/lib/cmd_maintenance.sh
@@ -123,9 +123,8 @@ cmd_doctor() {
         if [ -d "$_wt_parent" ] && [ -w "$_wt_parent" ]; then
             print_success "Worktree parent writable: $_wt_parent"
         else
-            doctor_fail "Worktree parent is not writable: $_wt_parent" \
-                "run hydra from a repository whose parent directory is writable, or see README Quick Start"
-            errors=$((errors + 1))
+            print_warning "Worktree parent is not writable: $_wt_parent"
+            echo "         Next: run hydra spawn from a repository whose parent is writable (see README Quick Start)"
         fi
     else
         doctor_info "Not in a git repository" \

--- a/lib/cmd_maintenance.sh
+++ b/lib/cmd_maintenance.sh
@@ -2,6 +2,22 @@
 # Hydra command handlers
 # POSIX-compliant shell script
 
+# Print a doctor failure with a concrete next action
+# Usage: doctor_fail <message> <next_action>
+doctor_fail() {
+    echo "  [FAIL] $1"
+    echo "         Next: $2"
+}
+
+# Print a doctor info line with optional next action
+# Usage: doctor_info <message> [next_action]
+doctor_info() {
+    echo "  [INFO] $1"
+    if [ -n "${2:-}" ]; then
+        echo "         Next: $2"
+    fi
+}
+
 cmd_doctor() {
     # Parse --fix flag
     fix_mode=0
@@ -21,58 +37,131 @@ cmd_doctor() {
     echo "================================="
     echo ""
 
-    # Check dependencies
-    echo "Checking dependencies..."
     errors=0
-    
-    # Check tmux
+
+    echo "Installation:"
+    echo "  Binary: ${HYDRA_BIN_CMD:-unknown}"
+    echo "  Libraries: ${HYDRA_LIB_DIR:-unknown}"
+    if [ -n "${HYDRA_ROOT:-}" ]; then
+        echo "  HYDRA_ROOT: $HYDRA_ROOT"
+    fi
+
+    _layout="unknown"
+    if [ -n "${HYDRA_ROOT:-}" ] && [ "$HYDRA_LIB_DIR" = "$HYDRA_ROOT/lib" ]; then
+        _layout="HYDRA_ROOT override"
+    elif [ -f "${HYDRA_BIN_DIR:-}/../lib/git.sh" ]; then
+        _layout="source checkout"
+    elif [ -f "${HYDRA_BIN_DIR:-}/../lib/hydra/git.sh" ]; then
+        _layout="PREFIX install"
+    elif [ "$HYDRA_LIB_DIR" = "/usr/local/lib/hydra" ]; then
+        _layout="legacy /usr/local"
+    fi
+    echo "  Layout: $_layout"
+
+    if [ -z "${HYDRA_LIB_DIR:-}" ] || [ ! -f "$HYDRA_LIB_DIR/git.sh" ]; then
+        doctor_fail "Library directory is missing or incomplete" \
+            "run bin/hydra from a source checkout, set HYDRA_ROOT, or reinstall with PREFIX=\$HOME/.local ./install.sh"
+        errors=$((errors + 1))
+    elif [ ! -x "${HYDRA_BIN_CMD:-}" ] && [ ! -f "${HYDRA_BIN_CMD:-}" ]; then
+        doctor_fail "Hydra binary path is not usable: ${HYDRA_BIN_CMD:-unset}" \
+            "reinstall with PREFIX=\$HOME/.local ./install.sh or run bin/hydra from the checkout"
+        errors=$((errors + 1))
+    else
+        print_success "Install and library paths resolve"
+    fi
+
+    echo ""
+    echo "Dependencies:"
+
     if command -v tmux >/dev/null 2>&1; then
-        if check_tmux_version; then
-            echo "  [OK] tmux $(tmux -V)"
+        if check_tmux_version 2>/dev/null; then
+            print_success "$(tmux -V) (need >= 3.0)"
         else
-            echo "  [FAIL] tmux version too old (need 3.0+)"
+            _tmux_ver="$(tmux -V 2>/dev/null || echo tmux)"
+            doctor_fail "$_tmux_ver is too old (need 3.0+)" \
+                "upgrade tmux to 3.0 or newer, then re-run hydra doctor"
             errors=$((errors + 1))
         fi
     else
-        echo "  [FAIL] tmux not installed"
+        doctor_fail "tmux is not installed" \
+            "install tmux 3.0 or newer (apt/brew), then re-run hydra doctor"
         errors=$((errors + 1))
     fi
-    
-    # Check git
+
     if command -v git >/dev/null 2>&1; then
-        echo "  [OK] $(git --version)"
+        print_success "$(git --version)"
     else
-        echo "  [FAIL] git not installed"
+        doctor_fail "git is not installed" \
+            "install git, then re-run hydra doctor"
         errors=$((errors + 1))
     fi
-    
-    # Check performance
+
     echo ""
-    echo "Running performance tests..."
-    
-    # Test command dispatch
-    start_time=$(date +%s%N 2>/dev/null || date +%s)
-    "$0" version >/dev/null 2>&1
-    end_time=$(date +%s%N 2>/dev/null || date +%s)
-    
-    if [ ${#start_time} -gt 10 ]; then
-        # Nanosecond precision available
-        elapsed=$(( (end_time - start_time) / 1000000 ))
-        echo "  Command dispatch: ${elapsed}ms"
+    echo "State:"
+    if [ -d "$HYDRA_HOME" ] && [ -w "$HYDRA_HOME" ]; then
+        print_success "HYDRA_HOME writable: $HYDRA_HOME"
     else
-        # Only second precision
-        echo "  Command dispatch: <1000ms (no precise timing available)"
+        doctor_fail "HYDRA_HOME is not writable: $HYDRA_HOME" \
+            "export HYDRA_HOME=\"\$HOME/.hydra\" and ensure that directory is writable"
+        errors=$((errors + 1))
     fi
-    
-    # Check state file
-    echo ""
-    echo "Checking state management..."
+
     if [ -f "$HYDRA_MAP" ]; then
         echo "  [OK] State file exists: $HYDRA_MAP"
         echo "    Size: $(wc -c < "$HYDRA_MAP") bytes"
         echo "    Entries: $(wc -l < "$HYDRA_MAP" | tr -d ' ')"
     else
-        echo "  [INFO] No state file (this is normal for new installations)"
+        doctor_info "No state file (this is normal for new installations)"
+    fi
+
+    echo ""
+    echo "Repository:"
+    if git rev-parse --git-dir >/dev/null 2>&1; then
+        _repo_root="$(get_repo_root 2>/dev/null || git rev-parse --show-toplevel)"
+        print_success "Git repository: $_repo_root"
+        _wt_parent="$(get_hydra_worktree_parent "$_repo_root" 2>/dev/null || dirname "$_repo_root")"
+        if [ -d "$_wt_parent" ] && [ -w "$_wt_parent" ]; then
+            print_success "Worktree parent writable: $_wt_parent"
+        else
+            doctor_fail "Worktree parent is not writable: $_wt_parent" \
+                "run hydra from a repository whose parent directory is writable, or see README Quick Start"
+            errors=$((errors + 1))
+        fi
+    else
+        doctor_info "Not in a git repository" \
+            "cd into a git repo, or create a throwaway repo (see README Quick Start)"
+    fi
+
+    echo ""
+    echo "Agents:"
+    _detected=""
+    for _agent in claude aider gemini codex cursor copilot; do
+        if command -v "$_agent" >/dev/null 2>&1; then
+            if [ -z "$_detected" ]; then
+                _detected="$_agent"
+            else
+                _detected="$_detected, $_agent"
+            fi
+        fi
+    done
+    if [ -n "$_detected" ]; then
+        print_success "Detected: $_detected"
+    else
+        doctor_info "No agent CLI detected" \
+            "export HYDRA_SKIP_AI=1 for a shell-only head, or install an agent (see README Quick Start)"
+    fi
+
+    echo ""
+    echo "Performance:"
+    start_time=$(date +%s%N 2>/dev/null || date +%s)
+    "$0" version >/dev/null 2>&1
+    end_time=$(date +%s%N 2>/dev/null || date +%s)
+
+    if [ ${#start_time} -gt 10 ]; then
+        elapsed=$(( (end_time - start_time) / 1000000 ))
+        echo "  Command dispatch: ${elapsed}ms"
+    else
+        echo "  Command dispatch: <1000ms (no precise timing available)"
     fi
 
     # Consistency checks
@@ -84,6 +173,7 @@ cmd_doctor() {
     dead_count="$(count_dead_sessions)"
     if [ "$dead_count" -gt 0 ]; then
         print_warning "Dead sessions: $dead_count (run 'hydra regenerate' to restore)"
+        echo "         Next: hydra regenerate   or   hydra doctor --fix"
         consistency_issues=$((consistency_issues + 1))
     else
         print_success "No dead sessions"
@@ -93,6 +183,7 @@ cmd_doctor() {
     orphan_wt="$(count_orphan_worktrees)"
     if [ "$orphan_wt" -gt 0 ]; then
         print_warning "Orphaned worktrees: $orphan_wt (run 'hydra cleanup' to remove)"
+        echo "         Next: hydra cleanup   or   hydra doctor --fix"
         consistency_issues=$((consistency_issues + 1))
     else
         print_success "No orphaned worktrees"
@@ -102,6 +193,7 @@ cmd_doctor() {
     stale_lock_count="$(count_stale_locks)"
     if [ "$stale_lock_count" -gt 0 ]; then
         print_warning "Stale locks: $stale_lock_count (run 'hydra cleanup' to remove)"
+        echo "         Next: hydra cleanup   or   hydra doctor --fix"
         consistency_issues=$((consistency_issues + 1))
     else
         print_success "No stale locks"
@@ -135,7 +227,7 @@ cmd_doctor() {
             echo "[WARN] Found $consistency_issues consistency issue(s). Run 'hydra doctor --fix' to auto-fix."
         fi
     else
-        echo "[FAIL] Found $errors issue(s). Please install missing dependencies."
+        echo "[FAIL] Found $errors issue(s). See Next: lines above for recovery."
         return 1
     fi
 }
@@ -233,4 +325,3 @@ EOF
     echo ""
     echo "Cleanup complete. Total items cleaned: $cleaned_total"
 }
-

--- a/lib/cmd_spawn.sh
+++ b/lib/cmd_spawn.sh
@@ -396,6 +396,7 @@ cmd_regenerate() {
     # Get repository root
     if ! git rev-parse --git-dir >/dev/null 2>&1; then
         echo "Error: Not in a git repository" >&2
+        echo "Next: cd into an existing git repo, or create a throwaway repo (see README Quick Start)" >&2
         return 1
     fi
     

--- a/lib/paths.sh
+++ b/lib/paths.sh
@@ -10,6 +10,7 @@
 get_repo_root() {
     if ! git rev-parse --git-dir >/dev/null 2>&1; then
         echo "Error: Not in a git repository" >&2
+        echo "Next: cd into an existing git repo, or create a throwaway repo (see README Quick Start)" >&2
         return 1
     fi
     git rev-parse --show-toplevel

--- a/lib/spawn.sh
+++ b/lib/spawn.sh
@@ -76,6 +76,26 @@ queue_mixed_spawns() {
     done
 }
 
+# Confirm an allowlisted AI command exists on PATH
+# Usage: ensure_ai_on_path <command>
+# Returns: 0 if found, 1 if missing
+ensure_ai_on_path() {
+    _ai="$1"
+    if [ -z "$_ai" ]; then
+        echo "Error: AI command cannot be empty" >&2
+        echo "Next: export HYDRA_SKIP_AI=1 for a shell-only head, or set HYDRA_AI_COMMAND to an installed agent" >&2
+        echo "See README Quick Start." >&2
+        return 1
+    fi
+    if ! command -v "$_ai" >/dev/null 2>&1; then
+        echo "Error: AI command '$_ai' is not installed or not on PATH" >&2
+        echo "Next: export HYDRA_SKIP_AI=1 to spawn a shell-only head, install '$_ai', or set HYDRA_AI_COMMAND" >&2
+        echo "See README Quick Start for the five-minute no-agent tour." >&2
+        return 1
+    fi
+    return 0
+}
+
 # Helper function to spawn a single session
 # Usage: spawn_single <branch> <layout> [ai_tool] [group] [deps] [pr_number] [template]
 # Returns: Session name on stdout, 1 on failure
@@ -110,7 +130,19 @@ spawn_single() {
     # Check if we're in a git repository
     if ! git rev-parse --git-dir >/dev/null 2>&1; then
         echo "Error: Not in a git repository" >&2
+        echo "Next: cd into an existing git repo, or create a throwaway repo (see README Quick Start)" >&2
         return 1
+    fi
+
+    # Fail fast if an agent is required but missing (before creating a worktree)
+    if [ -z "${HYDRA_SKIP_AI:-}" ]; then
+        _probe_ai="${ai_tool:-${HYDRA_AI_COMMAND:-claude}}"
+        if ! validate_ai_command "$_probe_ai"; then
+            return 1
+        fi
+        if ! ensure_ai_on_path "$_probe_ai"; then
+            return 1
+        fi
     fi
 
     # Get worktree path using consolidated path function
@@ -199,6 +231,10 @@ spawn_single() {
             ai_tool="${HYDRA_AI_COMMAND:-claude}"
         fi
         if ! validate_ai_command "$ai_tool"; then
+            spawn_rollback_session "$session" "$branch" "$worktree_path"
+            return 1
+        fi
+        if ! ensure_ai_on_path "$ai_tool"; then
             spawn_rollback_session "$session" "$branch" "$worktree_path"
             return 1
         fi
@@ -359,6 +395,9 @@ spawn_bulk_mixed() {
         fi
 
         if ! validate_ai_command "$agent"; then
+            return 1
+        fi
+        if [ -z "${HYDRA_SKIP_AI:-}" ] && ! ensure_ai_on_path "$agent"; then
             return 1
         fi
 

--- a/lib/tmux.sh
+++ b/lib/tmux.sh
@@ -10,6 +10,7 @@ validate_ai_command() {
     
     if [ -z "$command" ]; then
         echo "Error: AI command cannot be empty" >&2
+        echo "Next: export HYDRA_SKIP_AI=1 for a shell-only head, or set HYDRA_AI_COMMAND" >&2
         return 1
     fi
     
@@ -20,6 +21,7 @@ validate_ai_command() {
         *)
             echo "Error: Unsupported AI command: $command" >&2
             echo "Supported: claude, codex, cursor, copilot, aider, gemini" >&2
+            echo "Next: export HYDRA_SKIP_AI=1 for a shell-only head, or pass --ai with a supported tool" >&2
             return 1
             ;;
     esac
@@ -30,7 +32,8 @@ validate_ai_command() {
 # Returns: 0 if tmux >= 3.0, 1 otherwise
 check_tmux_version() {
     if ! command -v tmux >/dev/null 2>&1; then
-        echo "Error: tmux not found in PATH" >&2
+        echo "Error: tmux is not installed or not on PATH" >&2
+        echo "Next: install tmux 3.0 or newer (apt/brew), then run hydra doctor" >&2
         return 1
     fi
     
@@ -43,6 +46,7 @@ check_tmux_version() {
     
     if [ "$major_num" -lt 3 ]; then
         echo "Error: tmux version $version is too old (need >= 3.0)" >&2
+        echo "Next: upgrade tmux to 3.0 or newer, then run hydra doctor" >&2
         return 1
     fi
     

--- a/tests/test_bulk_spawn_integration.sh
+++ b/tests/test_bulk_spawn_integration.sh
@@ -13,6 +13,8 @@ test_dir=""
 
 # Hydra binary path - use current directory's hydra
 HYDRA_BIN="${HYDRA_BIN:-$original_dir/bin/hydra}"
+export HYDRA_SKIP_AI=1
+export HYDRA_NONINTERACTIVE=1
 
 # Test helper functions
 # shellcheck disable=SC2329

--- a/tests/test_dashboard.sh
+++ b/tests/test_dashboard.sh
@@ -7,6 +7,8 @@ TEST_REPO_DIR="/tmp/hydra_dashboard_test"
 TEST_BRANCHES="feature/test-1 feature/test-2 feature/test-3"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 HYDRA_BIN="$SCRIPT_DIR/../bin/hydra"
+export HYDRA_SKIP_AI=1
+export HYDRA_NONINTERACTIVE=1
 
 # Colors for output (if supported)
 if [ -t 1 ] && command -v tput >/dev/null 2>&1; then

--- a/tests/test_dashboard.sh
+++ b/tests/test_dashboard.sh
@@ -5,6 +5,8 @@
 # Test configuration
 TEST_REPO_DIR="/tmp/hydra_dashboard_test"
 TEST_BRANCHES="feature/test-1 feature/test-2 feature/test-3"
+UNRELATED_TEST_DIR="/tmp/hydra-unrelated-dashboard-$$"
+UNRELATED_TEST_SESSION="hydra-unrelated-dashboard-$$"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 HYDRA_BIN="$SCRIPT_DIR/../bin/hydra"
 export HYDRA_SKIP_AI=1
@@ -39,6 +41,21 @@ print_error() {
     echo "${RED}[ERROR]${RESET} $1"
 }
 
+cleanup_test_directories() {
+    rm -rf "$TEST_REPO_DIR" /tmp/test_hydra_home 2>/dev/null || true
+
+    for branch in $TEST_BRANCHES; do
+        worktree_path="/tmp/hydra-$branch"
+        rm -rf "$worktree_path" 2>/dev/null || true
+
+        # Slash-containing branch names share a test-owned parent.
+        parent_dir="$(dirname "$worktree_path")"
+        if [ "$parent_dir" != "/tmp" ]; then
+            rmdir "$parent_dir" 2>/dev/null || true
+        fi
+    done
+}
+
 # Comprehensive pre-test cleanup
 cleanup_all_test_sessions() {
     print_status "Performing comprehensive pre-test cleanup..."
@@ -46,54 +63,21 @@ cleanup_all_test_sessions() {
     # Kill all test-related tmux sessions
     tmux list-sessions -F '#{session_name}' 2>/dev/null | while IFS= read -r session; do
         case "$session" in
-            feature_test*|test-*|hydra-*|test_*)
+            feature_test-1|feature_test-2|feature_test-3|hydra-dashboard|hydra-dash-sanity|test-init)
                 print_status "  Cleaning up session: $session"
                 tmux kill-session -t "$session" 2>/dev/null || true
                 ;;
         esac
     done
-    
-    # Clean up test directories
-    rm -rf "$TEST_REPO_DIR" 2>/dev/null || true
-    rm -rf /tmp/hydra-* 2>/dev/null || true
-    rm -rf /tmp/test_hydra_home 2>/dev/null || true
-    
-    # Clean up any test HYDRA_HOME directories
-    find /tmp -maxdepth 2 -name ".hydra" -type d 2>/dev/null | while IFS= read -r dir; do
-        parent="$(dirname "$dir")"
-        case "$parent" in
-            /tmp/hydra*|/tmp/test*)
-                print_status "  Removing test hydra home: $dir"
-                rm -rf "$dir" 2>/dev/null || true
-                ;;
-        esac
-    done
+
+    cleanup_test_directories
 }
 
 # Setup test environment
 setup_test_repo() {
     print_status "Setting up test repository..."
-    
-    # Clean up any existing test directory
-    rm -rf "$TEST_REPO_DIR"
-    
-    # Clean up all hydra worktrees from previous runs
-    # First remove top-level hydra-* directories
-    rm -rf /tmp/hydra-* 2>/dev/null || true
-    
-    # Then handle worktrees with slashes in branch names (e.g., feature/test-1)
-    # These create subdirectories like /tmp/hydra-feature/test-1
-    for branch in $TEST_BRANCHES; do
-        worktree_path="/tmp/hydra-$branch"
-        if [ -d "$worktree_path" ]; then
-            rm -rf "$worktree_path" 2>/dev/null || true
-        fi
-        # Clean up parent directory if empty (e.g., /tmp/hydra-feature)
-        parent_dir="$(dirname "$worktree_path")"
-        if [ -d "$parent_dir" ] && [ "$parent_dir" != "/tmp" ]; then
-            rmdir "$parent_dir" 2>/dev/null || true
-        fi
-    done
+
+    cleanup_test_directories
     
     # Create test repository
     mkdir -p "$TEST_REPO_DIR"
@@ -566,6 +550,10 @@ test_multi_pane_collection_env() {
 # Cleanup test environment
 cleanup_test_env() {
     print_status "Cleaning up test environment..."
+
+    # Remove only the unrelated sentinels created by this test.
+    tmux kill-session -t "$UNRELATED_TEST_SESSION" 2>/dev/null || true
+    rmdir "$UNRELATED_TEST_DIR" 2>/dev/null || true
     
     cd "$TEST_REPO_DIR" || return 0
     
@@ -589,21 +577,7 @@ cleanup_test_env() {
     
     # Remove test repository and worktrees
     cd /tmp || return 0
-    rm -rf "$TEST_REPO_DIR"
-    # Remove all hydra worktrees, including those with slashes in branch names
-    rm -rf /tmp/hydra-* 2>/dev/null || true
-    # Also remove any parent directories created by branch names with slashes
-    for branch in $TEST_BRANCHES; do
-        worktree_path="/tmp/hydra-$branch"
-        if [ -d "$worktree_path" ]; then
-            rm -rf "$worktree_path" 2>/dev/null || true
-        fi
-        # Clean up parent directory if empty
-        parent_dir="$(dirname "$worktree_path")"
-        if [ -d "$parent_dir" ] && [ "$parent_dir" != "/tmp" ]; then
-            rmdir "$parent_dir" 2>/dev/null || true
-        fi
-    done
+    cleanup_test_directories
     
     print_status "Test environment cleaned up"
 }
@@ -637,9 +611,23 @@ main() {
     
     # Set up cleanup trap
     trap cleanup_test_env EXIT INT TERM
+
+    # A dashboard test run must not sweep unrelated hydra-* resources.
+    mkdir -p "$UNRELATED_TEST_DIR"
+    tmux new-session -d -s "$UNRELATED_TEST_SESSION"
     
     # Perform comprehensive cleanup before starting tests
     cleanup_all_test_sessions
+    if [ ! -d "$UNRELATED_TEST_DIR" ]; then
+        print_error "Pre-test cleanup removed an unrelated hydra-* directory"
+        exit 1
+    fi
+    if ! tmux has-session -t "$UNRELATED_TEST_SESSION" 2>/dev/null; then
+        print_error "Pre-test cleanup killed an unrelated hydra-* tmux session"
+        exit 1
+    fi
+    tmux kill-session -t "$UNRELATED_TEST_SESSION" 2>/dev/null || true
+    rmdir "$UNRELATED_TEST_DIR" 2>/dev/null || true
     
     # Run tests
     test_failed=0

--- a/tests/test_install.sh
+++ b/tests/test_install.sh
@@ -9,7 +9,7 @@ fail_count=0
 # shellcheck disable=SC1091
 . "$(dirname "$0")/helpers.sh"
 
-REPO_ROOT="$(CDPATH= cd "$(dirname "$0")/.." && pwd)"
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 HYDRA_SRC="$REPO_ROOT/bin/hydra"
 ORIGINAL_HOME="${HOME:-}"
 
@@ -87,21 +87,11 @@ assert_contains "$output" "Libraries: $prefix1/lib/hydra" "install.sh should rep
 assert_file "$prefix1/bin/hydra" "install.sh installs the binary"
 assert_file "$prefix1/lib/hydra/git.sh" "install.sh installs libraries"
 
-ver_out="$(
-    unset HYDRA_ROOT
-    unset HYDRA_HOME
-    HOME="$home1"
-    "$prefix1/bin/hydra" version 2>&1
-)"
+ver_out="$(HOME="$home1" HYDRA_ROOT='' HYDRA_HOME='' "$prefix1/bin/hydra" version 2>&1)"
 assert_success $? "installed hydra version should succeed"
 assert_contains "$ver_out" "Hydra version 1.5.2" "installed hydra reports 1.5.2"
 
-doc_out="$(
-    unset HYDRA_ROOT
-    HOME="$home1"
-    HYDRA_HOME="$home1/.hydra"
-    "$prefix1/bin/hydra" doctor 2>&1
-)"
+doc_out="$(cd "$home1" && HOME="$home1" HYDRA_HOME="$home1/.hydra" HYDRA_ROOT='' "$prefix1/bin/hydra" doctor 2>&1)"
 assert_success $? "installed hydra doctor should succeed"
 assert_contains "$doc_out" "PREFIX install" "doctor should detect PREFIX layout"
 assert_contains "$doc_out" "$prefix1/lib/hydra" "doctor should name installed libraries"
@@ -138,11 +128,7 @@ assert_contains "$output" "Libraries: $prefix2/lib/hydra" "make install should r
 assert_file "$prefix2/bin/hydra" "make install installs the binary"
 assert_file "$prefix2/lib/hydra/git.sh" "make install installs libraries"
 
-ver_out="$(
-    unset HYDRA_ROOT
-    HOME="$home2"
-    "$prefix2/bin/hydra" version 2>&1
-)"
+ver_out="$(HOME="$home2" HYDRA_ROOT='' HYDRA_HOME='' "$prefix2/bin/hydra" version 2>&1)"
 assert_success $? "make-installed hydra version should succeed"
 assert_contains "$ver_out" "Hydra version" "make-installed hydra prints version"
 
@@ -160,23 +146,11 @@ rm -rf "$home2" "$prefix2"
 echo "Testing make install DESTDIR staging..."
 stage="$(mktemp -d)"
 home3="$(mktemp -d)"
-output="$(
-    cd "$REPO_ROOT" || exit 1
-    HOME="$home3"
-    export HOME
-    unset HYDRA_HOME
-    unset HYDRA_ROOT
-    make install PREFIX=/usr/local DESTDIR="$stage" 2>&1
-)"
+output="$(cd "$REPO_ROOT" && HOME="$home3" HYDRA_HOME='' HYDRA_ROOT='' make install PREFIX=/usr/local DESTDIR="$stage" 2>&1)"
 assert_success $? "make install DESTDIR should succeed"
 assert_file "$stage/usr/local/bin/hydra" "DESTDIR stages the binary"
 assert_file "$stage/usr/local/lib/hydra/git.sh" "DESTDIR stages libraries"
-ver_out="$(
-    unset HYDRA_ROOT
-    unset HYDRA_HOME
-    HOME="$home3"
-    "$stage/usr/local/bin/hydra" version 2>&1
-)"
+ver_out="$(HOME="$home3" HYDRA_ROOT='' HYDRA_HOME='' "$stage/usr/local/bin/hydra" version 2>&1)"
 assert_success $? "DESTDIR-staged hydra should discover sibling libraries"
 HOME="$home3" PREFIX=/usr/local DESTDIR="$stage" sh "$REPO_ROOT/uninstall.sh" --purge >/dev/null 2>&1 || true
 rm -rf "$stage" "$home3"

--- a/tests/test_install.sh
+++ b/tests/test_install.sh
@@ -1,0 +1,229 @@
+#!/bin/sh
+# Fresh-prefix install, verification, and uninstall tests
+# Must not create branches or worktrees in the Hydra source repository.
+
+test_count=0
+pass_count=0
+fail_count=0
+
+# shellcheck disable=SC1091
+. "$(dirname "$0")/helpers.sh"
+
+REPO_ROOT="$(CDPATH= cd "$(dirname "$0")/.." && pwd)"
+HYDRA_SRC="$REPO_ROOT/bin/hydra"
+ORIGINAL_HOME="${HOME:-}"
+
+assert_contains() {
+    text="$1"
+    pattern="$2"
+    message="$3"
+
+    test_count=$((test_count + 1))
+    if echo "$text" | grep -q "$pattern"; then
+        pass_count=$((pass_count + 1))
+        echo "[PASS] $message"
+    else
+        fail_count=$((fail_count + 1))
+        echo "[FAIL] $message"
+        echo "  Text does not contain: '$pattern'"
+        echo "  Actual text: '$text'"
+    fi
+}
+
+assert_file() {
+    path="$1"
+    message="$2"
+    test_count=$((test_count + 1))
+    if [ -f "$path" ]; then
+        pass_count=$((pass_count + 1))
+        echo "[PASS] $message"
+    else
+        fail_count=$((fail_count + 1))
+        echo "[FAIL] $message"
+        echo "  Missing: $path"
+    fi
+}
+
+assert_no_file() {
+    path="$1"
+    message="$2"
+    test_count=$((test_count + 1))
+    if [ ! -e "$path" ]; then
+        pass_count=$((pass_count + 1))
+        echo "[PASS] $message"
+    else
+        fail_count=$((fail_count + 1))
+        echo "[FAIL] $message"
+        echo "  Still exists: $path"
+    fi
+}
+
+snapshot_source_repo() {
+    (cd "$REPO_ROOT" && git worktree list && git branch --list)
+}
+
+echo "Running install/uninstall PREFIX tests..."
+echo "========================================"
+
+SRC_BEFORE="$(snapshot_source_repo)"
+
+# --- install.sh to a writable prefix ---
+echo "Testing install.sh to a writable PREFIX..."
+home1="$(mktemp -d)"
+prefix1="$(mktemp -d)"
+export HOME="$home1"
+unset HYDRA_ROOT
+unset HYDRA_HOME
+
+output="$(
+    cd "$REPO_ROOT" || exit 1
+    PREFIX="$prefix1" sh ./install.sh 2>&1
+)"
+exit_code=$?
+assert_success "$exit_code" "install.sh should succeed on a writable PREFIX"
+assert_contains "$output" "Hydra version" "install.sh should run hydra version"
+assert_contains "$output" "Binary: $prefix1/bin/hydra" "install.sh should report binary path"
+assert_contains "$output" "Libraries: $prefix1/lib/hydra" "install.sh should report library path"
+assert_file "$prefix1/bin/hydra" "install.sh installs the binary"
+assert_file "$prefix1/lib/hydra/git.sh" "install.sh installs libraries"
+
+ver_out="$(
+    unset HYDRA_ROOT
+    unset HYDRA_HOME
+    HOME="$home1"
+    "$prefix1/bin/hydra" version 2>&1
+)"
+assert_success $? "installed hydra version should succeed"
+assert_contains "$ver_out" "Hydra version 1.5.2" "installed hydra reports 1.5.2"
+
+doc_out="$(
+    unset HYDRA_ROOT
+    HOME="$home1"
+    HYDRA_HOME="$home1/.hydra"
+    "$prefix1/bin/hydra" doctor 2>&1
+)"
+assert_success $? "installed hydra doctor should succeed"
+assert_contains "$doc_out" "PREFIX install" "doctor should detect PREFIX layout"
+assert_contains "$doc_out" "$prefix1/lib/hydra" "doctor should name installed libraries"
+
+un_out="$(
+    cd "$REPO_ROOT" || exit 1
+    PREFIX="$prefix1" sh ./uninstall.sh --purge 2>&1
+)"
+assert_success $? "uninstall.sh should succeed for the same PREFIX"
+assert_contains "$un_out" "Binary removed from: $prefix1/bin/hydra" "uninstall reports binary path"
+assert_contains "$un_out" "Libraries removed from: $prefix1/lib/hydra" "uninstall reports library path"
+assert_no_file "$prefix1/bin/hydra" "uninstall.sh removes the binary"
+assert_no_file "$prefix1/lib/hydra" "uninstall.sh removes the library directory"
+
+rm -rf "$home1" "$prefix1"
+
+# --- make install / make uninstall ---
+echo "Testing make install to a writable PREFIX..."
+home2="$(mktemp -d)"
+prefix2="$(mktemp -d)"
+export HOME="$home2"
+unset HYDRA_ROOT
+unset HYDRA_HOME
+
+output="$(
+    cd "$REPO_ROOT" || exit 1
+    make install PREFIX="$prefix2" 2>&1
+)"
+exit_code=$?
+assert_success "$exit_code" "make install should succeed on a writable PREFIX"
+assert_contains "$output" "Hydra version" "make install should run hydra version"
+assert_contains "$output" "Binary: $prefix2/bin/hydra" "make install should report binary path"
+assert_contains "$output" "Libraries: $prefix2/lib/hydra" "make install should report library path"
+assert_file "$prefix2/bin/hydra" "make install installs the binary"
+assert_file "$prefix2/lib/hydra/git.sh" "make install installs libraries"
+
+ver_out="$(
+    unset HYDRA_ROOT
+    HOME="$home2"
+    "$prefix2/bin/hydra" version 2>&1
+)"
+assert_success $? "make-installed hydra version should succeed"
+assert_contains "$ver_out" "Hydra version" "make-installed hydra prints version"
+
+un_out="$(
+    cd "$REPO_ROOT" || exit 1
+    PREFIX="$prefix2" sh ./uninstall.sh --purge 2>&1
+)"
+assert_success $? "make-install prefix can be uninstalled"
+assert_no_file "$prefix2/bin/hydra" "make uninstall path removes the binary"
+assert_no_file "$prefix2/lib/hydra" "make uninstall path removes libraries"
+
+rm -rf "$home2" "$prefix2"
+
+# --- DESTDIR staging ---
+echo "Testing make install DESTDIR staging..."
+stage="$(mktemp -d)"
+home3="$(mktemp -d)"
+output="$(
+    cd "$REPO_ROOT" || exit 1
+    HOME="$home3"
+    export HOME
+    unset HYDRA_HOME
+    unset HYDRA_ROOT
+    make install PREFIX=/usr/local DESTDIR="$stage" 2>&1
+)"
+assert_success $? "make install DESTDIR should succeed"
+assert_file "$stage/usr/local/bin/hydra" "DESTDIR stages the binary"
+assert_file "$stage/usr/local/lib/hydra/git.sh" "DESTDIR stages libraries"
+ver_out="$(
+    unset HYDRA_ROOT
+    unset HYDRA_HOME
+    HOME="$home3"
+    "$stage/usr/local/bin/hydra" version 2>&1
+)"
+assert_success $? "DESTDIR-staged hydra should discover sibling libraries"
+HOME="$home3" PREFIX=/usr/local DESTDIR="$stage" sh "$REPO_ROOT/uninstall.sh" --purge >/dev/null 2>&1 || true
+rm -rf "$stage" "$home3"
+
+# --- non-writable prefix ---
+echo "Testing non-writable PREFIX recovery..."
+output="$(PREFIX="/proc/hydra-no-write-$$" sh "$REPO_ROOT/install.sh" 2>&1)"
+exit_code=$?
+assert_failure "$exit_code" "install.sh should fail on a non-writable PREFIX"
+assert_contains "$output" "PREFIX is not writable" "non-writable PREFIX names the precondition"
+assert_contains "$output" "Next:" "non-writable PREFIX names a recovery action"
+assert_contains "$output" "HOME/.local" "recovery suggests PREFIX=\$HOME/.local"
+
+# --- source tree unchanged ---
+SRC_AFTER="$(snapshot_source_repo)"
+test_count=$((test_count + 1))
+if [ "$SRC_BEFORE" = "$SRC_AFTER" ]; then
+    pass_count=$((pass_count + 1))
+    echo "[PASS] source repository worktrees and branches are unchanged"
+else
+    fail_count=$((fail_count + 1))
+    echo "[FAIL] source repository worktrees or branches changed"
+    echo "  Before: $SRC_BEFORE"
+    echo "  After: $SRC_AFTER"
+fi
+
+# Restore HOME so later hydra invocations do not use a deleted prefix
+if [ -n "$ORIGINAL_HOME" ]; then
+    HOME="$ORIGINAL_HOME"
+    export HOME
+fi
+unset HYDRA_HOME
+
+# Source hydra still works from checkout
+src_ver="$("$HYDRA_SRC" version 2>&1)"
+assert_contains "$src_ver" "Hydra version" "run-from-source hydra version still works"
+
+echo ""
+echo "Test Results:"
+echo "  Total:  $test_count"
+echo "  Passed: $pass_count"
+echo "  Failed: $fail_count"
+
+if [ "$fail_count" -eq 0 ]; then
+    echo "All tests passed!"
+    exit 0
+else
+    echo "Some tests failed!"
+    exit 1
+fi

--- a/tests/test_integration.sh
+++ b/tests/test_integration.sh
@@ -235,9 +235,13 @@ test_doctor_command() {
     output="$("$HYDRA_BIN" doctor 2>&1)"
     exit_code=$?
     assert_success "$exit_code" "hydra doctor should succeed"
-    assert_contains "$output" "Checking dependencies" "Doctor output should contain dependencies check"
+    assert_contains "$output" "Dependencies:" "Doctor output should contain dependencies check"
+    assert_contains "$output" "Installation:" "Doctor should report install paths"
     assert_contains "$output" "tmux" "Doctor should check tmux"
     assert_contains "$output" "git" "Doctor should check git"
+    assert_contains "$output" "HYDRA_HOME" "Doctor should check writable HYDRA_HOME"
+    assert_contains "$output" "Agents:" "Doctor should report detected agents"
+    assert_contains "$output" "Libraries:" "Doctor should report library path"
     
     cleanup_test_env "$test_dir"
 }
@@ -351,7 +355,7 @@ test_issue_branch_cleanup() {
     
     # Create the branch and worktree
     echo "  Creating test branch '$test_branch'..."
-    output="$("$HYDRA_BIN" spawn "$test_branch" 2>&1)"
+    output="$(HYDRA_SKIP_AI=1 "$HYDRA_BIN" spawn "$test_branch" 2>&1)"
     exit_code=$?
     
     if [ "$exit_code" -ne 0 ]; then

--- a/tests/test_kill_all.sh
+++ b/tests/test_kill_all.sh
@@ -9,6 +9,7 @@ fail_count=0
 
 # Get the absolute path to hydra binary
 HYDRA_BIN="$(cd "$(dirname "$0")/.." && pwd)/bin/hydra"
+export HYDRA_SKIP_AI=1
 
 # CI environment detection
 if [ -n "${GITHUB_ACTIONS:-}" ] || [ -n "${CI:-}" ]; then

--- a/tests/test_onboarding.sh
+++ b/tests/test_onboarding.sh
@@ -9,7 +9,7 @@ fail_count=0
 # shellcheck disable=SC1091
 . "$(dirname "$0")/helpers.sh"
 
-REPO_ROOT="$(CDPATH= cd "$(dirname "$0")/.." && pwd)"
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 HYDRA_BIN="$REPO_ROOT/bin/hydra"
 
 assert_contains() {
@@ -43,17 +43,7 @@ repo_dir="$base_dir/repo"
 hydra_home="$base_dir/.hydra"
 mkdir -p "$repo_dir" "$hydra_home"
 
-cleanup() {
-    if [ -n "${branch:-}" ]; then
-        tmux kill-session -t "$branch" 2>/dev/null || true
-        (cd "$repo_dir" && HYDRA_HOME="$hydra_home" HYDRA_SKIP_AI=1 HYDRA_NONINTERACTIVE=1 \
-            "$HYDRA_BIN" kill "$branch" >/dev/null 2>&1) || true
-    fi
-    if [ -n "$base_dir" ] && [ -d "$base_dir" ]; then
-        rm -rf "$base_dir"
-    fi
-}
-trap cleanup EXIT INT TERM
+trap 'tmux kill-session -t "${branch:-}" 2>/dev/null || true; rm -rf "$base_dir"' EXIT INT TERM
 
 export HOME="$base_dir"
 export HYDRA_HOME="$hydra_home"
@@ -107,7 +97,7 @@ else
     assert_failure 0 "worktree lives under the throwaway parent"
 fi
 
-kill_out="$("$HYDRA_BIN" kill "$branch" 2>&1)"
+"$HYDRA_BIN" kill "$branch" >/dev/null 2>&1
 assert_success $? "hydra kill should clean up the first head"
 
 if tmux has-session -t "$branch" 2>/dev/null; then

--- a/tests/test_onboarding.sh
+++ b/tests/test_onboarding.sh
@@ -1,0 +1,199 @@
+#!/bin/sh
+# Throwaway-repository, no-agent first-head onboarding smoke test.
+# Must not create branches or worktrees in the Hydra source repository.
+
+test_count=0
+pass_count=0
+fail_count=0
+
+# shellcheck disable=SC1091
+. "$(dirname "$0")/helpers.sh"
+
+REPO_ROOT="$(CDPATH= cd "$(dirname "$0")/.." && pwd)"
+HYDRA_BIN="$REPO_ROOT/bin/hydra"
+
+assert_contains() {
+    text="$1"
+    pattern="$2"
+    message="$3"
+
+    test_count=$((test_count + 1))
+    if echo "$text" | grep -q "$pattern"; then
+        pass_count=$((pass_count + 1))
+        echo "[PASS] $message"
+    else
+        fail_count=$((fail_count + 1))
+        echo "[FAIL] $message"
+        echo "  Text does not contain: '$pattern'"
+        echo "  Actual text: '$text'"
+    fi
+}
+
+snapshot_source_repo() {
+    (cd "$REPO_ROOT" && git worktree list && git branch --list)
+}
+
+echo "Running onboarding smoke tests..."
+echo "================================="
+
+SRC_BEFORE="$(snapshot_source_repo)"
+
+base_dir="$(mktemp -d)" || exit 1
+repo_dir="$base_dir/repo"
+hydra_home="$base_dir/.hydra"
+mkdir -p "$repo_dir" "$hydra_home"
+
+cleanup() {
+    if [ -n "${branch:-}" ]; then
+        tmux kill-session -t "$branch" 2>/dev/null || true
+        (cd "$repo_dir" && HYDRA_HOME="$hydra_home" HYDRA_SKIP_AI=1 HYDRA_NONINTERACTIVE=1 \
+            "$HYDRA_BIN" kill "$branch" >/dev/null 2>&1) || true
+    fi
+    if [ -n "$base_dir" ] && [ -d "$base_dir" ]; then
+        rm -rf "$base_dir"
+    fi
+}
+trap cleanup EXIT INT TERM
+
+export HOME="$base_dir"
+export HYDRA_HOME="$hydra_home"
+export HYDRA_SKIP_AI=1
+export HYDRA_NONINTERACTIVE=1
+unset HYDRA_ROOT
+
+# --- run-from-source verify ---
+echo "Testing run-from-source verify..."
+ver_out="$("$HYDRA_BIN" version 2>&1)"
+assert_success $? "hydra version from source should succeed"
+assert_contains "$ver_out" "Hydra version" "version prints the contract line"
+
+doc_out="$("$HYDRA_BIN" doctor 2>&1)"
+assert_success $? "hydra doctor from source should succeed"
+assert_contains "$doc_out" "Installation:" "doctor reports installation"
+assert_contains "$doc_out" "source checkout" "doctor detects source layout"
+assert_contains "$doc_out" "HYDRA_HOME writable" "doctor reports writable home"
+assert_contains "$doc_out" "Agents:" "doctor reports agents"
+
+# --- throwaway repo first head ---
+echo "Testing throwaway-repository first head..."
+cd "$repo_dir" || exit 1
+git init >/dev/null 2>&1
+git config user.name "Onboarding Test"
+git config user.email "onboarding@example.com"
+echo "# throwaway" > README.md
+git add README.md
+git commit -m "init" >/dev/null 2>&1
+
+branch="first-head"
+spawn_out="$("$HYDRA_BIN" spawn "$branch" 2>&1)"
+assert_success $? "HYDRA_SKIP_AI=1 spawn should succeed without an agent"
+assert_contains "$spawn_out" "Creating worktree" "spawn creates a worktree"
+assert_contains "$spawn_out" "Creating tmux session" "spawn creates a tmux session"
+
+list_out="$("$HYDRA_BIN" list 2>&1)"
+assert_success $? "hydra list should succeed after spawn"
+assert_contains "$list_out" "$branch" "list shows the first head"
+
+if tmux has-session -t "$branch" 2>/dev/null; then
+    assert_success 0 "tmux session exists for the first head"
+else
+    assert_failure 0 "tmux session exists for the first head"
+fi
+
+wt_path="$base_dir/hydra-$branch"
+if [ -d "$wt_path" ]; then
+    assert_success 0 "worktree lives under the throwaway parent"
+else
+    assert_failure 0 "worktree lives under the throwaway parent"
+fi
+
+kill_out="$("$HYDRA_BIN" kill "$branch" 2>&1)"
+assert_success $? "hydra kill should clean up the first head"
+
+if tmux has-session -t "$branch" 2>/dev/null; then
+    assert_failure 0 "tmux session is gone after kill"
+else
+    assert_success 0 "tmux session is gone after kill"
+fi
+
+if [ -d "$wt_path" ]; then
+    assert_failure 0 "worktree is gone after kill"
+else
+    assert_success 0 "worktree is gone after kill"
+fi
+
+if [ -f "$HYDRA_HOME/map" ] && grep -q "$branch" "$HYDRA_HOME/map" 2>/dev/null; then
+    assert_failure 0 "state map no longer lists the first head"
+else
+    assert_success 0 "state map no longer lists the first head"
+fi
+
+# --- missing agent recovery (only when claude is absent) ---
+echo "Testing missing-agent first-run error..."
+if command -v claude >/dev/null 2>&1; then
+    echo "[SKIP] claude is on PATH; missing-agent error not asserted"
+else
+    missing_out="$(
+        unset HYDRA_SKIP_AI
+        "$HYDRA_BIN" spawn missing-agent-head 2>&1
+    )"
+    missing_code=$?
+    assert_failure "$missing_code" "spawn without HYDRA_SKIP_AI fails when claude is missing"
+    assert_contains "$missing_out" "not installed or not on PATH" "missing agent names the precondition"
+    assert_contains "$missing_out" "HYDRA_SKIP_AI=1" "missing agent names HYDRA_SKIP_AI recovery"
+    if [ -d "$base_dir/hydra-missing-agent-head" ]; then
+        assert_failure 0 "missing-agent spawn does not leave a worktree"
+        rm -rf "$base_dir/hydra-missing-agent-head"
+    else
+        assert_success 0 "missing-agent spawn does not leave a worktree"
+    fi
+    git -C "$repo_dir" branch -D missing-agent-head >/dev/null 2>&1 || true
+fi
+
+# --- not in a git repository ---
+echo "Testing not-in-git-repo first-run error..."
+nogit="$(mktemp -d)"
+nogit_out="$(
+    cd "$nogit" || exit 1
+    HYDRA_HOME="$hydra_home" HYDRA_SKIP_AI=1 "$HYDRA_BIN" spawn stray 2>&1
+)"
+nogit_code=$?
+assert_failure "$nogit_code" "spawn outside a git repo should fail"
+assert_contains "$nogit_out" "Not in a git repository" "not-in-repo names the precondition"
+assert_contains "$nogit_out" "Next:" "not-in-repo names a recovery action"
+assert_contains "$nogit_out" "README Quick Start" "not-in-repo points at the Quick Start"
+rm -rf "$nogit"
+
+# --- source tree unchanged ---
+SRC_AFTER="$(snapshot_source_repo)"
+test_count=$((test_count + 1))
+if [ "$SRC_BEFORE" = "$SRC_AFTER" ]; then
+    pass_count=$((pass_count + 1))
+    echo "[PASS] Hydra source repository has no new worktrees or branches"
+else
+    fail_count=$((fail_count + 1))
+    echo "[FAIL] Hydra source repository worktrees or branches changed"
+    echo "  Before: $SRC_BEFORE"
+    echo "  After: $SRC_AFTER"
+fi
+
+# Extra safety: no hydra-* worktrees under the source parent that we created
+if git -C "$REPO_ROOT" worktree list | grep -q "hydra-first-head\|hydra-missing-agent"; then
+    assert_failure 0 "no onboarding worktrees attached to the source repo"
+else
+    assert_success 0 "no onboarding worktrees attached to the source repo"
+fi
+
+echo ""
+echo "Test Results:"
+echo "  Total:  $test_count"
+echo "  Passed: $pass_count"
+echo "  Failed: $fail_count"
+
+if [ "$fail_count" -eq 0 ]; then
+    echo "All tests passed!"
+    exit 0
+else
+    echo "Some tests failed!"
+    exit 1
+fi

--- a/tests/test_onboarding.sh
+++ b/tests/test_onboarding.sh
@@ -64,6 +64,13 @@ assert_contains "$doc_out" "source checkout" "doctor detects source layout"
 assert_contains "$doc_out" "HYDRA_HOME writable" "doctor reports writable home"
 assert_contains "$doc_out" "Agents:" "doctor reports agents"
 
+# Replay the documented run-from-source PATH setup before leaving the checkout.
+export HYDRA_ROOT="$REPO_ROOT"
+export PATH="$HYDRA_ROOT/bin:$PATH"
+path_ver_out="$(hydra version 2>&1)"
+assert_success $? "documented run-from-source PATH setup should find hydra"
+assert_contains "$path_ver_out" "Hydra version" "PATH-resolved hydra runs from source"
+
 # --- throwaway repo first head ---
 echo "Testing throwaway-repository first head..."
 cd "$repo_dir" || exit 1
@@ -75,12 +82,12 @@ git add README.md
 git commit -m "init" >/dev/null 2>&1
 
 branch="first-head"
-spawn_out="$("$HYDRA_BIN" spawn "$branch" 2>&1)"
+spawn_out="$(hydra spawn "$branch" 2>&1)"
 assert_success $? "HYDRA_SKIP_AI=1 spawn should succeed without an agent"
 assert_contains "$spawn_out" "Creating worktree" "spawn creates a worktree"
 assert_contains "$spawn_out" "Creating tmux session" "spawn creates a tmux session"
 
-list_out="$("$HYDRA_BIN" list 2>&1)"
+list_out="$(hydra list 2>&1)"
 assert_success $? "hydra list should succeed after spawn"
 assert_contains "$list_out" "$branch" "list shows the first head"
 
@@ -97,7 +104,7 @@ else
     assert_failure 0 "worktree lives under the throwaway parent"
 fi
 
-"$HYDRA_BIN" kill "$branch" >/dev/null 2>&1
+hydra kill "$branch" >/dev/null 2>&1
 assert_success $? "hydra kill should clean up the first head"
 
 if tmux has-session -t "$branch" 2>/dev/null; then
@@ -116,6 +123,14 @@ if [ -f "$HYDRA_HOME/map" ] && grep -q "$branch" "$HYDRA_HOME/map" 2>/dev/null; 
     assert_failure 0 "state map no longer lists the first head"
 else
     assert_success 0 "state map no longer lists the first head"
+fi
+
+git branch -D "$branch" >/dev/null 2>&1
+assert_success $? "Quick Start should remove the disposable branch"
+if git show-ref --verify --quiet "refs/heads/$branch"; then
+    assert_failure 0 "disposable branch is gone after cleanup"
+else
+    assert_success 0 "disposable branch is gone after cleanup"
 fi
 
 # --- missing agent recovery (only when claude is absent) ---

--- a/tests/test_session_hooks.sh
+++ b/tests/test_session_hooks.sh
@@ -6,6 +6,8 @@ pass_count=0
 fail_count=0
 
 HYDRA_BIN="$(cd "$(dirname "$0")/.." && pwd)/bin/hydra"
+export HYDRA_SKIP_AI=1
+export HYDRA_NONINTERACTIVE=1
 
 assert_contains() {
     haystack="$1"

--- a/tests/test_yaml_config.sh
+++ b/tests/test_yaml_config.sh
@@ -6,6 +6,8 @@ pass_count=0
 fail_count=0
 
 HYDRA_BIN="$(cd "$(dirname "$0")/.." && pwd)/bin/hydra"
+export HYDRA_SKIP_AI=1
+export HYDRA_NONINTERACTIVE=1
 
 assert_true() {
     cond="$1"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,18 +1,22 @@
 #!/bin/sh
 # Uninstall script for hydra
 # POSIX-compliant uninstallation script
+# Removes $PREFIX/bin/hydra and $PREFIX/lib/hydra (default PREFIX=/usr/local).
 
 set -e
 
-# Check for root permissions
-if [ "$(id -u)" -ne 0 ]; then
-    echo "This script requires root permissions. Please run with sudo." >&2
-    exit 1
-fi
+usage() {
+    echo "Usage: [PREFIX=/usr/local] [DESTDIR=] ./uninstall.sh [--purge]" >&2
+    echo "  PREFIX    installation prefix (default: /usr/local)" >&2
+    echo "  DESTDIR   optional staging directory prepended to PREFIX" >&2
+    echo "  --purge   Remove user data non-interactively (HYDRA_HOME and ~/.hydra)" >&2
+    echo "" >&2
+    echo "Non-root example:" >&2
+    echo "  PREFIX=\$HOME/.local ./uninstall.sh" >&2
+}
 
 PURGE=false
 
-# Parse options
 while [ $# -gt 0 ]; do
     case "$1" in
         --purge)
@@ -20,26 +24,40 @@ while [ $# -gt 0 ]; do
             shift
             ;;
         -h|--help)
-            echo "Usage: sudo ./uninstall.sh [--purge]" >&2
-            echo "  --purge   Remove user data non-interactively (HYDRA_HOME and ~/.hydra)" >&2
+            usage
             exit 0
             ;;
         *)
             echo "Error: Unknown option '$1'" >&2
-            echo "Usage: sudo ./uninstall.sh [--purge]" >&2
+            echo "Next: run ./uninstall.sh --help for usage" >&2
+            usage
             exit 1
             ;;
     esac
 done
 
-echo "Uninstalling hydra..."
+PREFIX="${PREFIX:-/usr/local}"
+DESTDIR="${DESTDIR:-}"
 
-# Installation directories
-BIN_DIR="/usr/local/bin"
-LIB_DIR="/usr/local/lib/hydra"
+case "$PREFIX" in
+    /*) ;;
+    *)
+        PREFIX="$(pwd)/$PREFIX"
+        ;;
+esac
+
+BIN_DIR="${DESTDIR}${PREFIX}/bin"
+LIB_DIR="${DESTDIR}${PREFIX}/lib/hydra"
+
+echo "Uninstalling hydra from $PREFIX..."
 
 # Remove the binary
 if [ -f "$BIN_DIR/hydra" ]; then
+    if [ ! -w "$BIN_DIR" ] && [ ! -w "$BIN_DIR/hydra" ]; then
+        echo "Error: PREFIX is not writable: $BIN_DIR" >&2
+        echo "Next: PREFIX=\$HOME/.local $0   or   sudo env PREFIX=$PREFIX $0" >&2
+        exit 1
+    fi
     echo "Removing hydra binary..."
     rm -f "$BIN_DIR/hydra"
 else
@@ -48,6 +66,11 @@ fi
 
 # Remove library directory
 if [ -d "$LIB_DIR" ]; then
+    if [ ! -w "$LIB_DIR" ] && [ ! -w "$(dirname "$LIB_DIR")" ]; then
+        echo "Error: PREFIX is not writable: $LIB_DIR" >&2
+        echo "Next: PREFIX=\$HOME/.local $0   or   sudo env PREFIX=$PREFIX $0" >&2
+        exit 1
+    fi
     echo "Removing library files..."
     rm -rf "$LIB_DIR"
 else
@@ -77,7 +100,7 @@ for USER_DATA in $CANDIDATE_DIRS; do
         *" $USER_DATA "*) continue ;;
         *) seen="$seen $USER_DATA" ;;
     esac
-    
+
     if [ -d "$USER_DATA" ]; then
         echo ""
         echo "User data found at $USER_DATA"
@@ -103,3 +126,5 @@ done
 
 echo ""
 echo "Hydra has been uninstalled."
+echo "Binary removed from: $BIN_DIR/hydra"
+echo "Libraries removed from: $LIB_DIR"


### PR DESCRIPTION
## Summary

Implements Hydra 1.5.2 (Frictionless First Run): a five-minute, agent-optional onboarding path without new lifecycle architecture.

This PR includes the follow-up lint, doctor, onboarding-review, and test-isolation fixes. The repository ruleset is now scoped to `main`, so PR branches accept iterative follow-up pushes.

- **Non-root PREFIX install:** `$PREFIX/bin/hydra` and `$PREFIX/lib/hydra`. `install.sh` and `make install` share one contract, run `hydra version`, and print exact binary and library paths. Matching uninstall; optional `DESTDIR`.
- **Library discovery:** `HYDRA_ROOT`, source `../lib`, PREFIX `../lib/hydra`, then legacy `/usr/local/lib/hydra`.
- **Doctor:** install layout, git/tmux versions, writable `HYDRA_HOME`, repo/worktree readiness, detected agents, and a `Next:` recovery for every failure. An unwritable worktree parent is a warning, not a hard fail.
- **First-run errors:** missing libraries, tmux, git repo, unwritable home/prefix, and a missing default agent all name the precondition and the next command or doc. Spawn fails if the agent is not on `PATH` unless `HYDRA_SKIP_AI=1`. No `--no-agent` flag (deferred to 1.6).
- **Docs:** README Quick Start is a throwaway-repo tour with an obvious shell-only path, a replayable run-from-source setup, explicit disposable-branch cleanup, and user-level completions.
- **Tests:** `make test-install` and `make smoke-onboarding` never create branches or worktrees in this repository. Dashboard tests remove only their own fixtures and verify unrelated `hydra-*` directories and tmux sessions survive.

## Test plan

- [x] `make lint`
- [x] `make test` (including the install, onboarding, and dashboard isolation suites; `Failed: 0`)
- [x] `make test-install`
- [x] `make smoke-onboarding`
- [x] Verify the documented run-from-source `PATH` setup still resolves `hydra` after leaving the checkout
- [x] Verify disposable cleanup removes the tmux session, worktree, branch, and map entry
- [x] Verify dashboard cleanup preserves unrelated `/tmp/hydra-*` directories and `hydra-*` tmux sessions
- [x] Confirm a non-writable prefix fails with a `Next:` recovery
