### PR TITLE
docs: finalize 2.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0] - 2026-09-04
+
 ### Added
 
 - Native TUI keyboard help, a dashboard palette action, and structured spawn prompts

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,53 +1,49 @@
-# Hydra v1.9.0 Release Notes
+# Hydra v2.0.0 Release Notes
 
-Release date: 2026-09-02
+Release date: 2026-09-04
 
-Hydra 1.9.0 closes the local coordination loop: a trusted finite workflow can create
-and operate parallel heads, preserve authoritative results across interruption, and
-feed completed candidates into an isolated verified integration or guarded merge
-train. Promotion remains an explicit local action and never pushes.
+Hydra 2.0.0 establishes the stable local orchestration interface. Native mission
+control is now the default TUI when available, the basic shell TUI remains the
+compiler-free fallback, and state v2 is the sole runtime authority.
 
 ## Highlights
 
-- Workflow schema v1 rejects unknown keys and unsupported YAML constructs, requires
-  explicit idempotency, and supports `spawn`, `wait`, `exec`, `message`, `gate`,
-  `approve`, and `kill` steps.
-- The runner persists its resolved definition and manifest before execution, honors
-  bounded parallelism/retries/resources, propagates cancellation, and resumes stale
-  runs without replaying completed effects.
-- Verified integration previews candidate order, bases, claims, overlaps, and
-  predicted conflicts before creating a disposable worktree.
-- Integration reports retain immutable candidates and target, merge/gate evidence,
-  approval, result tree, observed failures, and a concrete recovery command.
-- `hydra integrate train` verifies after every candidate and promotes the complete
-  result only after current approval and binding revalidation.
-- Bash, Zsh, and Fish completions, an offline workflow example, and a fully local
-  workflow-to-integration acceptance fixture ship with the release candidate.
+- `hydra tui` launches native mission control by default, with visible fallback to
+  `hydra tui --basic` for missing, unsuitable, crashing, hanging, or version-skewed
+  native binaries.
+- Native mission control now covers structured spawn, keyboard help, dashboard
+  actions, search, branch-stable multi-selection, group assignment, and confirmed
+  bulk kill through public shell commands.
+- State-v2 project, head, and instance records replace runtime reads and writes of
+  the 1.9 compatibility maps across session, lifecycle, messaging, limits,
+  maintenance, dashboard, completion, and TUI surfaces.
+- Stable contracts define JSON success and error envelopes, lifecycle and workflow
+  evidence, native/basic parity, supported platforms, upgrades, deprecation, and the
+  consolidated local trust model.
+- Migration provides dry-run validation, full backup, verified removal of 1.9
+  projections, interruption safety, and explicit rollback for intentional downgrade.
 
-## Quick start
+## Upgrade from 1.9
 
 ```sh
-hydra init --no-agent --trust
-hydra workflow validate examples/workflows/local-review.yml
-hydra workflow dry-run examples/workflows/local-review.yml
-hydra workflow run examples/workflows/local-review.yml
-
-hydra integrate train release-group --base main --target main --dry-run --gate 'make test'
-hydra integrate train release-group --base main --target main --execute --gate 'make test'
-hydra integrate approve run_ID --by reviewer
-hydra integrate promote run_ID
+hydra state migrate --dry-run
+hydra state migrate
+hydra tui
 ```
 
-`hydra workflow status`, `cancel`, and `resume` manage workflow runs. Integration
-failures use the recovery command printed by `hydra integrate status run_ID`.
+Use `hydra tui --basic` to select the shell fallback explicitly. Use
+`hydra state rollback` only when intentionally downgrading to 1.9 after reviewing the
+recorded backup.
 
 ## Compatibility and safety
 
-The shell CLI remains the mutation authority. Native core protocol v1 and native TUI
-protocol v2 are unchanged; their release handshakes now report 1.9.0. Existing 1.8
-state remains valid. Repository workflows share the `.hydra` trust boundary, argv is
-the default execution form, and no workflow/integration command pushes or publishes.
+The POSIX shell CLI remains the sole mutation authority. Native core protocol v1 and
+native TUI protocol v2 remain unchanged, with exact 2.0.0 release handshakes. Hydra
+2.0 removes the runtime compatibility-map fallback, basic-TUI tag storage and tag
+actions, the one-key kill-all shortcut, preview-follow toggle, and redundant
+`hydra tui --native` mode.
 
-See [docs/workflows.md](docs/workflows.md) and
-[docs/RELEASE_CHECKLIST_1.9.0.md](docs/RELEASE_CHECKLIST_1.9.0.md) for contracts and
-the exact-candidate qualification/publication boundary.
+See [docs/MIGRATING_TO_2.0.md](docs/MIGRATING_TO_2.0.md),
+[docs/CONTRACTS.md](docs/CONTRACTS.md), and
+[docs/RELEASE_CHECKLIST_2.0.0.md](docs/RELEASE_CHECKLIST_2.0.0.md) for the migration,
+stable interfaces, and exact-candidate release boundary.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,9 +1,9 @@
 # Hydra Roadmap
 
 > - **Status:** canonical outstanding-work backlog
-> - **Snapshot:** 3 September 2026
-> - **Current release:** `v1.9.0` at `02b1cfb`
-> - **Next release candidate:** `2.0.0` stable local orchestration interface
+> - **Snapshot:** 4 September 2026
+> - **Current release:** `v2.0.0` stable local orchestration interface
+> - **Release planning:** versions are assigned from compatibility impact when backlog work is ready
 > - **Related:** [README](../README.md) · [CHANGELOG](../CHANGELOG.md) ·
 >   [Release policy](VERSIONING.md) · [Contracts](CONTRACTS.md) ·
 >   [2.0 release checklist](RELEASE_CHECKLIST_2.0.0.md)


### PR DESCRIPTION
## Summary

- mark the 2.0.0 changelog entry with its release date
- replace the stale 1.9 release notes with the 2.0 upgrade, compatibility, and feature summary
- move the roadmap snapshot to the post-2.0 release-time versioning model

## Qualification

- `make test-all`
- `make sanitize`
- `git diff --check`

This PR contains release metadata only. The v2.0.0 tag and hosted release will be created from the resulting main commit after exact-commit CI passes.