### PR TITLE
release: prepare Hydra 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0] - 2026-09-05
+
 ### Added
 
 - Local remote-task package preparation and inspection, binding an exact Git

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,49 +1,52 @@
-# Hydra v2.0.0 Release Notes
+# Hydra v2.1.0 Release Notes
 
-Release date: 2026-09-04
+Release date: 2026-09-05
 
-Hydra 2.0.0 establishes the stable local orchestration interface. Native mission
-control is now the default TUI when available, the basic shell TUI remains the
-compiler-free fallback, and state v2 is the sole runtime authority.
+Hydra 2.1.0 adds trusted remote fleets and disconnected task execution, with
+verified result collection and local integration. Native mission control gains
+clearer layouts, themes, and mouse navigation.
 
 ## Highlights
 
-- `hydra tui` launches native mission control by default, with visible fallback to
-  `hydra tui --basic` for missing, unsuitable, crashing, hanging, or version-skewed
-  native binaries.
-- Native mission control now covers structured spawn, keyboard help, dashboard
-  actions, search, branch-stable multi-selection, group assignment, and confirmed
-  bulk kill through public shell commands.
-- State-v2 project, head, and instance records replace runtime reads and writes of
-  the 1.9 compatibility maps across session, lifecycle, messaging, limits,
-  maintenance, dashboard, completion, and TUI surfaces.
-- Stable contracts define JSON success and error envelopes, lifecycle and workflow
-  evidence, native/basic parity, supported platforms, upgrades, deprecation, and the
-  consolidated local trust model.
-- Migration provides dry-run validation, full backup, verified removal of 1.9
-  projections, interruption safety, and explicit rollback for intentional downgrade.
+- Manage trusted SSH hosts with pinned installation, capability negotiation,
+  bounded observations, reconnect/reconcile, and instance-bound actions.
+- Submit an exact source commit and selected inputs, disconnect while a task or
+  finite workflow runs, then inspect status and logs or cancel it. Durable records
+  prevent duplicate execution and preserve uncertainty after lost responses.
+- Verify and collect result commits, artifacts, checksums, and gate evidence
+  without changing a dirty checkout. Integration still requires local gates and
+  explicit approval.
+- Use terminal, dark, or light themes, clearer branch/detail panels, mouse row
+  selection and scrolling, and complete keyboard navigation. Terminal modes are
+  restored on exit, signals, delegated commands, and fallback.
+- Install an optional prebuilt fleet helper with required/auto/never modes and
+  validation that preserves the existing installation when a helper is rejected.
 
-## Upgrade from 1.9
+## Upgrade and installation
 
-```sh
-hydra state migrate --dry-run
-hydra state migrate
-hydra tui
-```
+This is a backward-compatible upgrade from 2.0.0; state v2 and the existing core
+and TUI protocols remain unchanged. Upgrade the shell and optional native helpers
+together because their executable version handshakes must match.
 
-Use `hydra tui --basic` to select the shell fallback explicitly. Use
-`hydra state rollback` only when intentionally downgrading to 1.9 after reviewing the
-recorded backup.
+The attached tar.gz and zip archives contain the exact release source; SHA256SUMS
+verifies both downloads. The shell CLI remains compiler-free. To build the optional
+native helpers, use `make build-core build-tui build-fleet`; fleet additionally
+requires JSON-C development files and pkg-config. JSON-C is linked statically.
+Run `sh install.sh` from the unpacked source to install into the documented prefix.
 
-## Compatibility and safety
+Users upgrading from 1.9 should first follow the documented 2.0 state migration.
 
-The POSIX shell CLI remains the sole mutation authority. Native core protocol v1 and
-native TUI protocol v2 remain unchanged, with exact 2.0.0 release handshakes. Hydra
-2.0 removes the runtime compatibility-map fallback, basic-TUI tag storage and tag
-actions, the one-key kill-all shortcut, preview-follow toggle, and redundant
-`hydra tui --native` mode.
+## Trust and scope
 
-See [docs/MIGRATING_TO_2.0.md](docs/MIGRATING_TO_2.0.md),
-[docs/CONTRACTS.md](docs/CONTRACTS.md), and
-[docs/VERSIONING.md](docs/VERSIONING.md) for the migration,
-stable interfaces, and exact-candidate release boundary.
+Fleet is for trusted hosts and uses strict SSH host-key checks. Remote commands
+use structured arguments; bootstrap and result collection validate content and
+paths. Host-local trust and live state are never copied between hosts. A successful
+remote task does not confer review approval or permission to promote its result.
+
+Automatic placement, cross-host workflow graphs, scheduled task pools, and provider
+adapter expansion remain outside this release. Existing real-host acceptance is
+recorded separately from release-commit platform qualification.
+
+See [fleet setup](https://github.com/Someblueman/hydra/blob/v2.1.0/docs/FLEET.md),
+[remote tasks](https://github.com/Someblueman/hydra/blob/v2.1.0/docs/REMOTE_TASKS.md),
+and [migration guidance](https://github.com/Someblueman/hydra/blob/v2.1.0/docs/MIGRATING_TO_2.0.md).

--- a/bin/hydra
+++ b/bin/hydra
@@ -11,7 +11,7 @@ if [ -z "${HOME:-}" ] || [ ! -d "${HOME:-}" ]; then
 fi
 HYDRA_HOME="${HYDRA_HOME:-$HOME/.hydra}"
 HYDRA_1X_MAP="$HYDRA_HOME/map"
-HYDRA_VERSION="2.0.0"
+HYDRA_VERSION="2.1.0"
 export HYDRA_VERSION HYDRA_1X_MAP
 
 # Source helper libraries

--- a/docs/FLEET.md
+++ b/docs/FLEET.md
@@ -86,8 +86,8 @@ The handshake exposes Hydra version, fleet/state/event/JSON protocols, native
 protocol expectations and executable presence, project mappings, capabilities,
 and supported signals. Native presence does not certify helper compatibility.
 The coordinator requires Hydra 2.x, fleet protocol 1, state 2, event 1, JSON 1,
-and the requested capability. Released 2.0.0 predates fleet; bootstrap a qualified
-fleet build before using these commands.
+and the requested capability. Fleet is available from 2.1.0; build and bootstrap a qualified
+fleet helper before using these commands.
 
 List returns canonical durable head records, including remote project paths.
 Desired state is not live agent progress. Doctor retains the remote diagnostic

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -246,7 +246,7 @@ Delivered work is intentionally absent from this roadmap. Use these records inst
 - [CONTRACTS.md](CONTRACTS.md), [STATE.md](STATE.md), [EVENTS.md](EVENTS.md), and
   [AUTOMATION.md](AUTOMATION.md) for current local interfaces;
 - [FLEET.md](FLEET.md) and [FLEET_ACCEPTANCE.md](FLEET_ACCEPTANCE.md) for the
-  implemented fleet pilot awaiting release;
+  implemented fleet capability and historical pilot qualification;
 - [REMOTE_TASKS.md](REMOTE_TASKS.md) and [REMOTE_TASK_ACCEPTANCE.md](REMOTE_TASK_ACCEPTANCE.md)
   for remote submission, disconnected execution, verified collection, and qualification;
 - [workflows.md](workflows.md) for workflow and integration behavior;

--- a/src/fleet/fleet.h
+++ b/src/fleet/fleet.h
@@ -12,7 +12,7 @@
 #define F_LIMIT (8U * 1024U * 1024U)
 #define F_PATH 4096
 #define F_PROTOCOL 1
-#define F_VERSION "2.0.0"
+#define F_VERSION "2.1.0"
 struct f_capture { char *out, *err; int status; bool timeout, cancelled, stop_unknown; };
 /* Borrowed log descriptors and stop context; remaining budgets span invocations. */
 struct f_control {

--- a/src/hydra_tui.c
+++ b/src/hydra_tui.c
@@ -19,7 +19,7 @@
 #include <time.h>
 #include <unistd.h>
 
-#define HYDRA_TUI_VERSION "2.0.0"
+#define HYDRA_TUI_VERSION "2.1.0"
 #define HYDRA_TUI_PROTOCOL 2
 #define MAX_HEADS 512
 #define MAX_RECOVERY 512

--- a/src/libhydra.h
+++ b/src/libhydra.h
@@ -4,7 +4,7 @@
 #include <stddef.h>
 #include <stdio.h>
 
-#define HYDRA_CORE_VERSION "2.0.0"
+#define HYDRA_CORE_VERSION "2.1.0"
 #define HYDRA_PROTOCOL_VERSION 1
 
 int hydra_json_write_string(FILE *out, const char *value);

--- a/tests/fixtures/tui/crash-native.sh
+++ b/tests/fixtures/tui/crash-native.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 if [ "${1:-}" = --version ]; then
-    echo "Hydra TUI 2.0.0 protocol 2"
+    echo "Hydra TUI 2.1.0 protocol 2"
     exit 0
 fi
 

--- a/tests/test_core.sh
+++ b/tests/test_core.sh
@@ -142,7 +142,7 @@ printf '%s\n' \
     '  --protocol-version)' \
     '    case "${FAKE_CORE_MODE:-}" in skew) echo 99 ;; hang) sleep 3 ;; descendant) sleep 20 & echo $! > "$FAKE_CORE_CHILD_PID"; wait ;; crash) exit 9 ;; *) echo 1 ;; esac ;;' \
     '  --version)' \
-    '    case "${FAKE_CORE_MODE:-}" in version-skew) echo "Hydra core 0.0.0 protocol 1" ;; *) echo "Hydra core 2.0.0 protocol 1" ;; esac ;;' \
+    '    case "${FAKE_CORE_MODE:-}" in version-skew) echo "Hydra core 0.0.0 protocol 1" ;; *) echo "Hydra core 2.1.0 protocol 1" ;; esac ;;' \
     '  snapshot)' \
     '    case "${FAKE_CORE_MODE:-}" in malformed) echo not-json ;; shape) echo '\''{"schema_version":1,"ok":true,"command":"snapshot","data":{"state_schema":2,"projects":1,"heads":[{"project_id":false}]}}'\'' ;; crash) exit 9 ;; *) echo not-json ;; esac ;;' \
     'esac' > "$fake_core"

--- a/tests/test_fleet.sh
+++ b/tests/test_fleet.sh
@@ -20,7 +20,7 @@ case "$1" in
     offline) echo 'Connection refused' >&2; exit 255 ;;
     slow) [ -z "${HYDRA_TEST_SSH_PID:-}" ] || echo $$ > "$HYDRA_TEST_SSH_PID"; exec sleep 30 ;;
     malformed) echo '{bad json'; exit ;;
-    skew) printf '{"schema_version":1,"ok":true,"command":"fleet-handshake","data":{"hydra_version":"2.0.0","fleet_protocol":9,"capabilities":[]}}\n'; exit ;;
+    skew) printf '{"schema_version":1,"ok":true,"command":"fleet-handshake","data":{"hydra_version":"2.1.0","fleet_protocol":9,"capabilities":[]}}\n'; exit ;;
 esac
 exec /bin/sh -c "$2"
 SSH

--- a/tests/test_install.sh
+++ b/tests/test_install.sh
@@ -91,7 +91,7 @@ assert_file "$prefix1/lib/hydra/git.sh" "install.sh installs libraries"
 
 ver_out="$(HOME="$home1" HYDRA_ROOT='' HYDRA_HOME='' "$prefix1/bin/hydra" version 2>&1)"
 assert_success $? "installed hydra version should succeed"
-assert_contains "$ver_out" "Hydra version 2.0.0" "installed hydra reports 2.0.0"
+assert_contains "$ver_out" "Hydra version 2.1.0" "installed hydra reports 2.1.0"
 
 doc_out="$(cd "$home1" && HOME="$home1" HYDRA_HOME="$home1/.hydra" HYDRA_ROOT='' "$prefix1/bin/hydra" doctor 2>&1)"
 assert_success $? "installed hydra doctor should succeed"
@@ -100,7 +100,7 @@ assert_contains "$doc_out" "$prefix1/lib/hydra" "doctor should name installed li
 
 # Replace the installed binary with an older version marker, then reinstall into
 # the same prefix. User state lives outside PREFIX and must survive the upgrade.
-sed 's/HYDRA_VERSION="2.0.0"/HYDRA_VERSION="1.9.0"/' "$prefix1/bin/hydra" > "$prefix1/bin/hydra.upgrade"
+sed 's/HYDRA_VERSION="2.1.0"/HYDRA_VERSION="2.0.0"/' "$prefix1/bin/hydra" > "$prefix1/bin/hydra.upgrade"
 mv "$prefix1/bin/hydra.upgrade" "$prefix1/bin/hydra"
 chmod +x "$prefix1/bin/hydra"
 mkdir -p "$home1/.hydra"
@@ -111,7 +111,7 @@ printf '%s\n' 'preserve-upgrade-state' > "$home1/.hydra/upgrade-marker"
 ) >/dev/null
 assert_success $? "install.sh should upgrade an existing PREFIX"
 upgrade_ver="$(HOME="$home1" HYDRA_ROOT='' HYDRA_HOME='' "$prefix1/bin/hydra" version 2>&1)"
-assert_contains "$upgrade_ver" "Hydra version 2.0.0" "upgrade replaces the older binary"
+assert_contains "$upgrade_ver" "Hydra version 2.1.0" "upgrade replaces the older binary"
 assert_equal "preserve-upgrade-state" "$(sed -n '1p' "$home1/.hydra/upgrade-marker")" "upgrade preserves HYDRA_HOME state"
 
 un_out="$(

--- a/tests/test_native_install.sh
+++ b/tests/test_native_install.sh
@@ -155,10 +155,10 @@ HOME="$archive_home" PREFIX="$archive_prefix" HYDRA_INSTALL_CORE=required HYDRA_
     sh "$archive_checkout/install.sh" > "$test_root/archive-source.out" 2>&1
 assert_success $? "source archive auto-builds native TUI without Git metadata"
 assert_file "$archive_prefix/libexec/hydra/hydra-tui" "auto install builds and installs native TUI when a compiler is available"
-assert_equal "hydra-2.0.0-source-tree" \
+assert_equal "hydra-2.1.0-source-tree" \
     "$(sed -n '1p' "$archive_prefix/libexec/hydra/hydra-core.source")" \
     "source archive records explicit non-commit provenance"
-assert_equal "hydra-2.0.0-source-tree" \
+assert_equal "hydra-2.1.0-source-tree" \
     "$(sed -n '1p' "$archive_prefix/libexec/hydra/hydra-tui.source")" \
     "source archive records explicit native TUI provenance"
 

--- a/tests/test_native_tui.sh
+++ b/tests/test_native_tui.sh
@@ -64,7 +64,7 @@ echo "Running native TUI tests..."
 echo "==========================="
 
 assert_equal "2" "$("$tui" --protocol-version)" "native TUI protocol handshake"
-assert_equal "Hydra TUI 2.0.0 protocol 2" "$("$tui" --version)" "native TUI version handshake"
+assert_equal "Hydra TUI 2.1.0 protocol 2" "$("$tui" --version)" "native TUI version handshake"
 
 awk 'BEGIN { FS = OFS = "\t" } $1 == "H" && !changed { $13 = "invalid"; changed = 1 } { print }' \
     "$fixture" > "$test_root/invalid-number.tsv"
@@ -183,14 +183,14 @@ assert_failure $? "TERM=dumb fails cleanly"
 assert_failure $? "non-TTY invocation fails cleanly"
 
 # shellcheck disable=SC2016
-printf '#!/bin/sh\n[ "${1:-}" = --version ] && { echo "Hydra TUI 2.0.0 protocol 2"; exit 0; }\nexit 4\n' > "$test_root/native-transient"
+printf '#!/bin/sh\n[ "${1:-}" = --version ] && { echo "Hydra TUI 2.1.0 protocol 2"; exit 0; }\nexit 4\n' > "$test_root/native-transient"
 chmod +x "$test_root/native-transient"
 HYDRA_TUI_BIN="$test_root/native-transient" "$repo_root/bin/hydra" tui > /dev/null 2> "$test_root/fallback.err"
 assert_failure $? "non-TTY basic fallback still fails cleanly"
 contains "starting the basic TUI" "$test_root/fallback.err" "transient native failure dispatches to basic fallback"
 
 # shellcheck disable=SC2016
-printf '#!/bin/sh\n[ "${1:-}" = --version ] && { echo "Hydra TUI 2.0.0 protocol 2"; exit 0; }\nprintf "NATIVE DEFAULT\\n"\n' > "$test_root/native-success"
+printf '#!/bin/sh\n[ "${1:-}" = --version ] && { echo "Hydra TUI 2.1.0 protocol 2"; exit 0; }\nprintf "NATIVE DEFAULT\\n"\n' > "$test_root/native-success"
 chmod +x "$test_root/native-success"
 HYDRA_TUI_BIN="$test_root/native-success" "$repo_root/bin/hydra" tui > "$test_root/default.out"
 contains "NATIVE DEFAULT" "$test_root/default.out" "plain tui dispatches to a qualified native executable"


### PR DESCRIPTION
Prepare Hydra 2.1.0 for the merged fleet, remote-task, and native TUI capabilities. This is a backward-compatible minor release: update the shell/core/TUI/fleet version handshakes and their fixtures together, exercise installation over 2.0.0, finalize the changelog and release notes, and refresh released-feature guidance.

Validation: `make test-all`, `make sanitize`, and `git diff --check` pass locally, including all 39 onboarding checks. The feature merge at `26fc726` also passed all hosted checks. Release publication will follow qualification of this preparation's exact main merge, with source archives, checksums, and immutable publication.
