### PR TITLE
docs: restore Hydra logo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+<p align="center">
+  <a href="https://github.com/Someblueman/hydra">
+    <img width="300" height="200" src="assets/hydra.png" alt="Hydra Logo">
+  </a>
+</p>
+
 # Hydra
 
 **Native mission control for coding agents, worktrees, and remote fleets.**


### PR DESCRIPTION
Restore the existing Hydra logo above the README title, centered at its previous 300×200 size. The current README content and demo remain unchanged.

Validation: confirmed the image exists and git diff --check passes.