### PR TITLE
Release 2.2.0: workflow data and agent planning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.0] - 2026-09-07
+
 ### Added
 
 - Bounded JSON objective plans with public schema discovery, structured validation,
@@ -40,11 +42,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Contributor quality-hook pilot includes local shell checks and native C analysis.
 - Fleet task cancellation allows 30 seconds per transport phase and accepts a
   bounded `--timeout` override so suspended approval result sealing can finish.
-- Interactive Codex restore requires an exact recorded session identity instead of
-  implicitly selecting the latest session. Older heads remain inspectable; see
-  [the migration instructions](docs/AGENT_CONTRACT.md#workflow-profiles-and-migration).
+
+### Fixed
+
+- Workflow cancellation refreshes residual worker evidence before publishing terminal
+  state, avoiding stale residuals and false cancellation failures.
+- Agent cancellation reaches the native supervisor before its children so receipts
+  preserve the observed cancellation; deadline signals remain timeouts.
+- Git fingerprints reject failed or truncated probes. Agent result decoding rejects
+  malformed terminal records and embedded NUL data.
+- Shell lint remains compatible with ShellCheck 0.9.
+- Restore the Hydra logo in the README.
+
+### Compatibility
+
+- Interactive Codex heads preserve cwd-scoped `codex resume --last`, including
+  heads without a recorded provider session ID. Headless `hydra exec --resume-run`
+  uses only the exact session bound to the selected successful run receipt.
+- State v2 and existing core, TUI, fleet, event, and JSON protocol versions remain
+  unchanged. Upgrade the shell CLI and native helpers together.
+
+### Qualification
 
 Workflow-data and local planning acceptance are complete. Cursor local/remote,
 Antigravity remote, and Claude Code remote live qualification remain outstanding;
@@ -747,3 +768,6 @@ remote provider matrix and exact evidence.
 [0.2.0]: https://github.com/yourusername/hydra/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/yourusername/hydra/releases/tag/v0.1.0
 [1.2.0]: https://github.com/yourusername/hydra/compare/release/v1.1.0...release/v1.2.0
+
+[Unreleased]: https://github.com/Someblueman/hydra/compare/v2.2.0...HEAD
+[2.2.0]: https://github.com/Someblueman/hydra/compare/v2.1.0...v2.2.0

--- a/README.md
+++ b/README.md
@@ -24,10 +24,9 @@ use ordinary shell sessions alongside agents.
 
 [Demo transcript and recording instructions](assets/demos/README.md)
 
-This checkout includes unreleased workflow data, approval waits, headless adapters
-and local objective planning on top of **v2.1.0**. For published behavior use the
-[latest release](https://github.com/Someblueman/hydra/releases/latest); see the
-[changelog](CHANGELOG.md) for the source/release boundary.
+**v2.2.0** adds workflow data, approval waits, headless adapters, and local objective
+planning. Install the [latest release](https://github.com/Someblueman/hydra/releases/latest)
+and see the [changelog](CHANGELOG.md) for features and upgrade notes.
 
 ## What you can do
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,56 +1,63 @@
-# Hydra v2.1.0 Release Notes
+# Hydra v2.2.0 Release Notes
 
-Release date: 2026-09-05
+Release date: 2026-09-07
 
-These notes describe the published v2.1.0 release. New source-branch additions
-are recorded under [Unreleased in the changelog](CHANGELOG.md#unreleased); they
-are not part of v2.1.0.
-
-Hydra 2.1.0 adds trusted remote fleets and disconnected task execution, with
-verified result collection and local integration. Native mission control gains
-clearer layouts, themes, and mouse navigation.
+Hydra 2.2.0 adds workflows with named inputs, sealed artifacts, durable approvals,
+and retry policies. Headless agents run through explicit adapter contracts, while
+local objective plans compile into reviewable workflows accepted by exact digest.
 
 ## Highlights
 
-- Manage trusted SSH hosts with pinned installation, capability negotiation,
-  bounded observations, reconnect/reconcile, and instance-bound actions.
-- Submit an exact source commit and selected inputs, disconnect while a task or
-  finite workflow runs, then inspect status and logs or cancel it. Durable records
-  prevent duplicate execution and preserve uncertainty after lost responses.
-- Verify and collect result commits, artifacts, checksums, and gate evidence
-  without changing a dirty checkout. Integration still requires local gates and
-  explicit approval.
-- Use terminal, dark, or light themes, clearer branch/detail panels, mouse row
-  selection and scrolling, and complete keyboard navigation. Terminal modes are
-  restored on exit, signals, delegated commands, and fallback.
-- Install an optional prebuilt fleet helper with required/auto/never modes and
-  validation that preserves the existing installation when a helper is rejected.
+- Carry file and structured inputs between steps. Declared outputs are sealed and
+  verified before dependents consume them; missing or changed artifacts block work.
+- Suspend local workflows and remote tasks for durable approval, then resume with
+  decisions bound to the reviewed evidence. Declared idempotent steps can retry
+  selected failure classes with durable backoff deadlines.
+- Run headless agents with capability checks, bounded event translation, exact
+  recorded-session resume, safe-point steering, supervised cancellation, and
+  optional bounded payload retention. New profiles include Antigravity and Cursor
+  Agent, alongside expanded OpenCode integration.
+- Inspect and validate bounded JSON objective plans, preview their deterministic
+  compilation, and authorize local execution by exact digest. Final delivery
+  requires passing verification reports bound to sealed deliverable bytes.
+- Sign in to providers on selected fleet hosts or preview and explicitly approve
+  copying private credentials. Pi and OpenCode support selected-provider merges.
+- Receive reliable cancellation receipts and terminal workflow state, with failed
+  or truncated Git fingerprint probes and malformed agent output rejected.
 
-## Upgrade and installation
+## Compatibility and upgrade
 
-This is a backward-compatible upgrade from 2.0.0; state v2 and the existing core
-and TUI protocols remain unchanged. Upgrade the shell and optional native helpers
-together because their executable version handshakes must match.
+Upgrade the shell CLI and optional native helpers together: all executable version
+handshakes are now 2.2.0. Existing state v2, event/JSON schemas, and core, TUI, and
+fleet protocol versions remain unchanged. Existing command-based workflows remain
+supported; agent profiles and workflow data are opt-in additions.
+
+Interactive Codex heads preserve cwd-scoped `codex resume --last`, including heads
+without a recorded provider session identity. Headless `hydra exec --resume-run`
+remains separate: it resumes only the exact session in the selected successful
+run receipt, bound to the same head, instance, worktree, and profile. See the
+[agent resume contract](https://github.com/Someblueman/hydra/blob/v2.2.0/docs/AGENT_CONTRACT.md#workflow-profiles-and-migration).
 
 The attached tar.gz and zip archives contain the exact release source; SHA256SUMS
 verifies both downloads. The shell CLI remains compiler-free. To build the optional
 native helpers, use `make build-core build-tui build-fleet`; fleet additionally
 requires JSON-C development files and pkg-config. JSON-C is linked statically.
 Run `sh install.sh` from the unpacked source to install into the documented prefix.
-
 Users upgrading from 1.9 should first follow the documented 2.0 state migration.
 
-## Trust and scope
+## Scope and qualification limits
 
-Fleet is for trusted hosts and uses strict SSH host-key checks. Remote commands
-use structured arguments; bootstrap and result collection validate content and
-paths. Host-local trust and live state are never copied between hosts. A successful
-remote task does not confer review approval or permission to promote its result.
+Objective DAG execution is local. Cross-host DAG coordination, automatic placement,
+dynamic graph expansion, and scheduled task pools remain roadmap work. Remote
+workflows still execute on one selected host.
 
-Automatic placement, cross-host workflow graphs, scheduled task pools, and provider
-adapter expansion remain outside this release. Existing real-host acceptance is
-recorded separately from release-commit platform qualification.
+Provider capabilities and authentication differ by host. Cursor local/remote,
+Antigravity remote, and Claude Code remote live qualification remain outstanding;
+Claude remote sign-in is deferred. Fixture and platform tests do not replace those
+provider checks. See the
+[workflow and agent acceptance matrix](https://github.com/Someblueman/hydra/blob/v2.2.0/docs/WORKFLOW_AGENT_ACCEPTANCE.md)
+and [planning evidence](https://github.com/Someblueman/hydra/blob/v2.2.0/docs/evidence/plan-qualification.md).
 
-See [fleet setup](https://github.com/Someblueman/hydra/blob/v2.1.0/docs/FLEET.md),
-[remote tasks](https://github.com/Someblueman/hydra/blob/v2.1.0/docs/REMOTE_TASKS.md),
-and [migration guidance](https://github.com/Someblueman/hydra/blob/v2.1.0/docs/MIGRATING_TO_2.0.md).
+Fleet remains a trusted-host tool with strict SSH host-key checks. A successful
+agent run or collected remote result does not confer review approval or permission
+to promote it. Credential copying requires approval of the exact preview digest.

--- a/bin/hydra
+++ b/bin/hydra
@@ -11,7 +11,7 @@ if [ -z "${HOME:-}" ] || [ ! -d "${HOME:-}" ]; then
 fi
 HYDRA_HOME="${HYDRA_HOME:-$HOME/.hydra}"
 HYDRA_1X_MAP="$HYDRA_HOME/map"
-HYDRA_VERSION="2.1.0"
+HYDRA_VERSION="2.2.0"
 export HYDRA_VERSION HYDRA_1X_MAP
 
 # Source helper libraries

--- a/docs/AGENT_CONTRACT.md
+++ b/docs/AGENT_CONTRACT.md
@@ -164,19 +164,17 @@ transport; it does not establish that the model obeyed it. Live qualification mu
 compare actual results. A zero headless timeout is bounded internally to 24 hours;
 ordinary command-mode exec retains its existing timeout behavior.
 
-Interactive Codex restore no longer uses `resume --last`. `hydra resume HEAD`
-requires a recorded provider session ID and fails before recreating a missing
-worktree when no supported exact recipe is available. Older Codex heads without
-that identity remain inspectable. Start a headless exec and use its returned run ID
-with `--resume-run` for subsequent turns, or select the known provider session
-explicitly outside Hydra. Existing successful headless receipts remain tied to
-one current instance; they cannot be reused for a replacement instance.
+Interactive Codex restore retains cwd-scoped `codex resume --last`. `hydra resume HEAD`
+recreates the selected head's worktree/session and asks Codex for the latest
+conversation in that worktree; older heads do not need a recorded provider session
+ID. This interactive convenience does not claim an exact conversation identity.
 
-This is an intentional behavior change for callers relying on implicit latest
-session selection. There is no automatic migration that guesses a session identity.
-No existing state is deleted, and the shell-only launch and no-agent paths remain
-available. Headless-only imported profiles are invoked through `hydra exec`, not
-interactive spawn; inspect their complete declaration with `hydra agent contract`.
+Headless `hydra exec --resume-run RUN_ID` is a separate path. It requires a
+successful recorded run and resumes its exact provider session, never `--last`.
+The receipt must match the current head, instance, worktree, and profile. It cannot
+be reused for a replacement instance. Headless-only imported profiles are invoked
+through `hydra exec`, not interactive spawn; inspect their complete declaration
+with `hydra agent contract`.
 
 ## Host authentication
 

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -1,6 +1,6 @@
 # Hydra public contracts
 
-Hydra 3.0 retains state v2 and the existing local and fleet protocols, and adds
+Hydra 2.2.0 retains state v2 and the existing local and fleet protocols, and adds
 workflow data, approval, agent, and planning contracts. Interactive Codex restore
 retains cwd-scoped latest-session selection; headless resume binds an exact recorded
 session. See the [2.2.0 compatibility notes](../CHANGELOG.md#220---2026-09-07).

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -1,8 +1,10 @@
 # Hydra public contracts
 
-Hydra preserves the stable local interfaces introduced in 2.0 and the fleet
-interfaces shipped in 2.1.0. This document also describes the source-branch
-additions listed under [Unreleased](../CHANGELOG.md#unreleased). Internal shell function names,
+Hydra 3.0 retains state v2 and the existing local and fleet protocols, and adds
+workflow data, approval, agent, and planning contracts. Interactive Codex restore
+retains cwd-scoped latest-session selection; headless resume binds an exact recorded
+session. See the [2.2.0 compatibility notes](../CHANGELOG.md#220---2026-09-07).
+Internal shell function names,
 module layout, renderer details, caches, and on-disk temporary files are not public
 contracts.
 

--- a/docs/FLEET.md
+++ b/docs/FLEET.md
@@ -11,7 +11,7 @@ Successful committed results enter the existing local integration and approval
 flow. Existing direct remote workflow calls remain synchronous.
 
 Fleet and remote tasks shipped in v2.1.0. Headless provider execution and durable
-approval suspension are source-branch additions; see the [changelog](../CHANGELOG.md).
+approval suspension are available in v2.2.0; see the [changelog](../CHANGELOG.md).
 A remote workflow runs on one selected host. Cross-host DAG coordination and
 automatic placement remain on the [roadmap](ROADMAP.md).
 

--- a/docs/PROFILES.md
+++ b/docs/PROFILES.md
@@ -59,7 +59,7 @@ CLI. These profiles work without the native helper. `hydra agent list`, `show`,
 | `cursor` | `cursor-agent` | Positional prompt after `--` | No automatic session capture; use headless recorded resume |
 | `opencode` | `opencode` | `--prompt` | No automatic session capture; use headless recorded resume |
 | `claude` | `claude` | Positional prompt | Exact generated `--session-id` / `--resume` |
-| `codex` | `codex` | Positional prompt | `resume ID`, only with a recorded identity |
+| `codex` | `codex` | Positional prompt | cwd-scoped `resume --last` |
 | `copilot`, `aider`, `gemini` | Matching executable name | Not declared | Launch only |
 | custom | Explicit absolute executable | Declared `none` or `task-file` | Not declared |
 
@@ -103,5 +103,6 @@ New imports cannot replace a reserved built-in name. Inspect a pre-existing cust
 name before assuming it uses the built-in recipe; use a fresh profile name for
 customizations.
 
-Older Codex heads without an exact recorded session remain inspectable but cannot
-use implicit `resume --last`. See [the migration contract](AGENT_CONTRACT.md#workflow-profiles-and-migration).
+Interactive Codex heads retain cwd-scoped `resume --last`, including older heads
+without recorded provider session IDs. Headless `exec --resume-run` still requires
+an exact recorded session; see [the resume contract](AGENT_CONTRACT.md#workflow-profiles-and-migration).

--- a/docs/REMOTE_TASKS.md
+++ b/docs/REMOTE_TASKS.md
@@ -7,8 +7,8 @@ snapshots can be downloaded and collected into isolated local refs for the exist
 integration flow. See [local and real-host qualification](REMOTE_TASK_ACCEPTANCE.md)
 for tested boundaries. That dated record predates publication; the base remote
 task capability shipped in v2.1.0. Headless adapters and durable approval
-suspension described here are newer source additions; see the
-[changelog](../CHANGELOG.md#unreleased).
+suspension described here are available in v2.2.0; see the
+[changelog](../CHANGELOG.md#220---2026-09-07).
 
 ## Prepare and preview
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,7 +2,7 @@
 
 > - **Status:** canonical outstanding-work backlog
 > - **Snapshot:** 7 September 2026
-> - **Current release:** `v2.1.0` remote fleets and native mission control
+> - **Current release:** `v2.2.0` workflow data, agent adapters, and local objective planning
 > - **Release planning:** versions are assigned from compatibility impact when backlog work is ready
 > - **Related:** [README](../README.md) · [CHANGELOG](../CHANGELOG.md) ·
 >   [Release policy](VERSIONING.md) · [Contracts](CONTRACTS.md) ·

--- a/docs/SUPPORT.md
+++ b/docs/SUPPORT.md
@@ -17,7 +17,7 @@ when built from source. Trusted SSH fleet coordination shipped in v2.1.0;
 Windows, WSL-specific behavior and BSD userlands without the documented tools
 are not qualified platforms.
 
-The current source adds headless adapters and local objective planning. Provider
+Version 2.2.0 adds headless adapters and local objective planning. Provider
 authentication and live qualification are host-specific; see the
 [agent matrix](PROFILES.md). Cross-host objective DAGs and automatic load balancing
 remain roadmap work.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,9 +1,9 @@
 # Command and configuration guide
 
-See `hydra help` for complete command syntax. This guide covers the current branch.
-Fleet and [remote tasks](REMOTE_TASKS.md) shipped in v2.1.0. Workflow data,
-approval waits, headless adapters and local objective planning are additions in
-this checkout; see the [changelog](../CHANGELOG.md) for the release boundary.
+See `hydra help` for complete command syntax. Fleet and
+[remote tasks](REMOTE_TASKS.md) shipped in v2.1.0. Version 2.2.0 adds workflow data,
+approval waits, headless adapters, and local objective planning; see the
+[changelog](../CHANGELOG.md) for upgrade notes.
 
 
 ```sh

--- a/lib/profiles.sh
+++ b/lib/profiles.sh
@@ -45,7 +45,7 @@ profile_field() {
                 case "$_pf_name" in claude|codex|agy|cursor|opencode) printf 'task-file\n' ;; *) printf 'none\n' ;; esac
                 ;;
             resume_mode)
-                case "$_pf_name" in claude) printf 'session-id\n' ;; codex) printf 'exact-session\n' ;; *) printf 'none\n' ;; esac
+                case "$_pf_name" in claude) printf 'session-id\n' ;; codex) printf 'cwd-last\n' ;; *) printf 'none\n' ;; esac
                 ;;
             adapter) printf 'none\n' ;;
             confidence)
@@ -180,11 +180,7 @@ profile_resume_command() {
             printf '%s --resume %s\n' "$(profile_shell_quote "$(profile_field "$_prc_name" executable)")" \
                 "$(profile_shell_quote "$_prc_provider_id")"
             ;;
-        exact-session)
-            [ -n "$_prc_provider_id" ] || return 1
-            printf '%s resume %s\n' "$(profile_shell_quote "$(profile_field "$_prc_name" executable)")" \
-                "$(profile_shell_quote "$_prc_provider_id")"
-            ;;
+        cwd-last) printf '%s resume --last\n' "$(profile_shell_quote "$(profile_field "$_prc_name" executable)")" ;;
         *) return 1 ;;
     esac
 }

--- a/src/fleet/fleet.h
+++ b/src/fleet/fleet.h
@@ -12,7 +12,7 @@
 #define F_LIMIT (8U * 1024U * 1024U)
 #define F_PATH 4096
 #define F_PROTOCOL 1
-#define F_VERSION "2.1.0"
+#define F_VERSION "2.2.0"
 struct f_capture { char *out, *err; size_t out_bytes, err_bytes; int status; bool timeout, cancelled, stop_unknown; };
 /* Borrowed log descriptors and stop context; remaining budgets span invocations. */
 struct f_control {

--- a/src/hydra_tui.c
+++ b/src/hydra_tui.c
@@ -19,7 +19,7 @@
 #include <time.h>
 #include <unistd.h>
 
-#define HYDRA_TUI_VERSION "2.1.0"
+#define HYDRA_TUI_VERSION "2.2.0"
 #define HYDRA_TUI_PROTOCOL 2
 #define MAX_HEADS 512
 #define MAX_RECOVERY 512

--- a/src/libhydra.h
+++ b/src/libhydra.h
@@ -4,7 +4,7 @@
 #include <stddef.h>
 #include <stdio.h>
 
-#define HYDRA_CORE_VERSION "2.1.0"
+#define HYDRA_CORE_VERSION "2.2.0"
 #define HYDRA_PROTOCOL_VERSION 1
 
 int hydra_json_write_string(FILE *out, const char *value);

--- a/tests/agent_builtin_cases.sh
+++ b/tests/agent_builtin_cases.sh
@@ -7,13 +7,20 @@ cat > "$fixture/builtin-bin/provider" <<'PROVIDER'
 set -eu
 provider="${0##*/}"
 case " $* " in
-    *' --help '*|*' --version '*) printf '%s\n' 'fixture-1 --print --conversation --resume --session --format --output-format --disable-slash-commands stream-json'; exit 0 ;;
+    *' --help '*|*' --version '*) printf '%s\n' 'fixture-1 --print --conversation --resume --session --format --output-format --disable-slash-commands stream-json --json resume'; exit 0 ;;
 esac
 mode=start
 session=fixture-session
 prompt=''
 while [ "$#" -gt 0 ]; do
     case "$1" in
+        exec) [ "$provider" = codex ]; shift ;;
+        resume)
+            [ "$provider" = codex ] && [ "$2" = --json ]
+            mode=resume; session="$3"; shift 3 ;;
+        --json) [ "$provider" = codex ]; shift ;;
+        --color) [ "$provider" = codex ] && [ "$2" = never ]; shift 2 ;;
+        -) [ "$provider" = codex ]; prompt="$(cat)"; shift ;;
         run) [ "$provider" = opencode ]; shift ;;
         --format|--output-format) case "$2" in json|stream-json) ;; *) exit 64 ;; esac; shift 2 ;;
         --disable-slash-commands) [ "$provider" = agy ]; shift ;;
@@ -32,6 +39,7 @@ case "$prompt" in
     partial-provider) printf '{'; exit 0 ;;
     failed-provider)
         case "$adapter" in
+            codex) printf '%s\n' '{"type":"turn.failed"}' ;;
             agy) printf '%s\n' '{"event":"result","result":{"status":"WAITING"}}' ;;
             cursor) printf '%s\n' '{"type":"result","is_error":true}' ;;
             opencode) printf '%s\n' '{"type":"error"}' ;;
@@ -45,7 +53,7 @@ builtin_path="$PATH"
 PATH="$fixture/builtin-bin:$PATH"
 HYDRA_PROVIDER_FIXTURES="$root/tests/fixtures/agents"
 export PATH HYDRA_PROVIDER_FIXTURES
-for builtin in agy cursor opencode; do
+for builtin in codex agy cursor opencode; do
     case "$builtin" in cursor) executable=cursor-agent ;; *) executable="$builtin" ;; esac
     ln -s provider "$fixture/builtin-bin/$executable"
     # An option-shaped prompt stays data through each provider's literal recipe.

--- a/tests/fixtures/tui/crash-native.sh
+++ b/tests/fixtures/tui/crash-native.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 if [ "${1:-}" = --version ]; then
-    echo "Hydra TUI 2.1.0 protocol 2"
+    echo "Hydra TUI 2.2.0 protocol 2"
     exit 0
 fi
 

--- a/tests/test_core.sh
+++ b/tests/test_core.sh
@@ -142,7 +142,7 @@ printf '%s\n' \
     '  --protocol-version)' \
     '    case "${FAKE_CORE_MODE:-}" in skew) echo 99 ;; hang) sleep 3 ;; descendant) sleep 20 & echo $! > "$FAKE_CORE_CHILD_PID"; wait ;; crash) exit 9 ;; *) echo 1 ;; esac ;;' \
     '  --version)' \
-    '    case "${FAKE_CORE_MODE:-}" in version-skew) echo "Hydra core 0.0.0 protocol 1" ;; *) echo "Hydra core 2.1.0 protocol 1" ;; esac ;;' \
+    '    case "${FAKE_CORE_MODE:-}" in version-skew) echo "Hydra core 0.0.0 protocol 1" ;; *) echo "Hydra core 2.2.0 protocol 1" ;; esac ;;' \
     '  snapshot)' \
     '    case "${FAKE_CORE_MODE:-}" in malformed) echo not-json ;; shape) echo '\''{"schema_version":1,"ok":true,"command":"snapshot","data":{"state_schema":2,"projects":1,"heads":[{"project_id":false}]}}'\'' ;; crash) exit 9 ;; *) echo not-json ;; esac ;;' \
     'esac' > "$fake_core"

--- a/tests/test_install.sh
+++ b/tests/test_install.sh
@@ -91,7 +91,7 @@ assert_file "$prefix1/lib/hydra/git.sh" "install.sh installs libraries"
 
 ver_out="$(HOME="$home1" HYDRA_ROOT='' HYDRA_HOME='' "$prefix1/bin/hydra" version 2>&1)"
 assert_success $? "installed hydra version should succeed"
-assert_contains "$ver_out" "Hydra version 2.1.0" "installed hydra reports 2.1.0"
+assert_contains "$ver_out" "Hydra version 2.2.0" "installed hydra reports 2.2.0"
 
 doc_out="$(cd "$home1" && HOME="$home1" HYDRA_HOME="$home1/.hydra" HYDRA_ROOT='' "$prefix1/bin/hydra" doctor 2>&1)"
 assert_success $? "installed hydra doctor should succeed"
@@ -100,7 +100,7 @@ assert_contains "$doc_out" "$prefix1/lib/hydra" "doctor should name installed li
 
 # Replace the installed binary with an older version marker, then reinstall into
 # the same prefix. User state lives outside PREFIX and must survive the upgrade.
-sed 's/HYDRA_VERSION="2.1.0"/HYDRA_VERSION="2.0.0"/' "$prefix1/bin/hydra" > "$prefix1/bin/hydra.upgrade"
+sed 's/HYDRA_VERSION="2.2.0"/HYDRA_VERSION="2.1.0"/' "$prefix1/bin/hydra" > "$prefix1/bin/hydra.upgrade"
 mv "$prefix1/bin/hydra.upgrade" "$prefix1/bin/hydra"
 chmod +x "$prefix1/bin/hydra"
 mkdir -p "$home1/.hydra"
@@ -111,7 +111,7 @@ printf '%s\n' 'preserve-upgrade-state' > "$home1/.hydra/upgrade-marker"
 ) >/dev/null
 assert_success $? "install.sh should upgrade an existing PREFIX"
 upgrade_ver="$(HOME="$home1" HYDRA_ROOT='' HYDRA_HOME='' "$prefix1/bin/hydra" version 2>&1)"
-assert_contains "$upgrade_ver" "Hydra version 2.1.0" "upgrade replaces the older binary"
+assert_contains "$upgrade_ver" "Hydra version 2.2.0" "upgrade replaces the older binary"
 assert_equal "preserve-upgrade-state" "$(sed -n '1p' "$home1/.hydra/upgrade-marker")" "upgrade preserves HYDRA_HOME state"
 
 un_out="$(

--- a/tests/test_native_install.sh
+++ b/tests/test_native_install.sh
@@ -155,10 +155,10 @@ HOME="$archive_home" PREFIX="$archive_prefix" HYDRA_INSTALL_CORE=required HYDRA_
     sh "$archive_checkout/install.sh" > "$test_root/archive-source.out" 2>&1
 assert_success $? "source archive auto-builds native TUI without Git metadata"
 assert_file "$archive_prefix/libexec/hydra/hydra-tui" "auto install builds and installs native TUI when a compiler is available"
-assert_equal "hydra-2.1.0-source-tree" \
+assert_equal "hydra-2.2.0-source-tree" \
     "$(sed -n '1p' "$archive_prefix/libexec/hydra/hydra-core.source")" \
     "source archive records explicit non-commit provenance"
-assert_equal "hydra-2.1.0-source-tree" \
+assert_equal "hydra-2.2.0-source-tree" \
     "$(sed -n '1p' "$archive_prefix/libexec/hydra/hydra-tui.source")" \
     "source archive records explicit native TUI provenance"
 

--- a/tests/test_native_tui.sh
+++ b/tests/test_native_tui.sh
@@ -64,7 +64,7 @@ echo "Running native TUI tests..."
 echo "==========================="
 
 assert_equal "2" "$("$tui" --protocol-version)" "native TUI protocol handshake"
-assert_equal "Hydra TUI 2.1.0 protocol 2" "$("$tui" --version)" "native TUI version handshake"
+assert_equal "Hydra TUI 2.2.0 protocol 2" "$("$tui" --version)" "native TUI version handshake"
 
 awk 'BEGIN { FS = OFS = "\t" } $1 == "H" && !changed { $13 = "invalid"; changed = 1 } { print }' \
     "$fixture" > "$test_root/invalid-number.tsv"
@@ -183,14 +183,14 @@ assert_failure $? "TERM=dumb fails cleanly"
 assert_failure $? "non-TTY invocation fails cleanly"
 
 # shellcheck disable=SC2016
-printf '#!/bin/sh\n[ "${1:-}" = --version ] && { echo "Hydra TUI 2.1.0 protocol 2"; exit 0; }\nexit 4\n' > "$test_root/native-transient"
+printf '#!/bin/sh\n[ "${1:-}" = --version ] && { echo "Hydra TUI 2.2.0 protocol 2"; exit 0; }\nexit 4\n' > "$test_root/native-transient"
 chmod +x "$test_root/native-transient"
 HYDRA_TUI_BIN="$test_root/native-transient" "$repo_root/bin/hydra" tui > /dev/null 2> "$test_root/fallback.err"
 assert_failure $? "non-TTY basic fallback still fails cleanly"
 contains "starting the basic TUI" "$test_root/fallback.err" "transient native failure dispatches to basic fallback"
 
 # shellcheck disable=SC2016
-printf '#!/bin/sh\n[ "${1:-}" = --version ] && { echo "Hydra TUI 2.1.0 protocol 2"; exit 0; }\nprintf "NATIVE DEFAULT\\n"\n' > "$test_root/native-success"
+printf '#!/bin/sh\n[ "${1:-}" = --version ] && { echo "Hydra TUI 2.2.0 protocol 2"; exit 0; }\nprintf "NATIVE DEFAULT\\n"\n' > "$test_root/native-success"
 chmod +x "$test_root/native-success"
 HYDRA_TUI_BIN="$test_root/native-success" "$repo_root/bin/hydra" tui > "$test_root/default.out"
 contains "NATIVE DEFAULT" "$test_root/default.out" "plain tui dispatches to a qualified native executable"

--- a/tests/test_profiles.sh
+++ b/tests/test_profiles.sh
@@ -32,10 +32,9 @@ echo "=============================="
 assert_equal none "$(profile_resolve none)" "none is a first-class profile"
 assert_equal task-file "$(profile_field claude prompt_mode)" "Claude task transport is declared"
 assert_equal session-id "$(profile_field claude resume_mode)" "Claude resume recipe is declared"
-assert_equal exact-session "$(profile_field codex resume_mode)" "Codex resume requires an exact recorded session"
-assert_equal "'codex' resume 'recorded-session'" "$(profile_resume_command codex recorded-session)" "Codex resume selects only the supplied identity"
-profile_resume_command codex '' >/dev/null 2>&1
-assert_failure $? "Codex resume cannot select a most-recent session"
+assert_equal cwd-last "$(profile_field codex resume_mode)" "Codex interactive resume remains cwd-scoped"
+assert_equal "'codex' resume --last" "$(profile_resume_command codex '')" "Codex interactive resume supports heads without recorded IDs"
+assert_equal "'codex' resume --last" "$(profile_resume_command codex recorded-session)" "Codex interactive recipe stays separate from headless exact resume"
 assert_equal cursor-agent "$(profile_field cursor executable)" "Cursor profile selects the agent CLI"
 for builtin in agy cursor opencode; do
     profile_exists "$builtin"


### PR DESCRIPTION
Prepare Hydra 2.2.0 with matching shell, core, TUI, and fleet version handshakes. Finalize the changelog and release notes for workflow data, durable approvals and retries, headless agent adapters, host authentication, and digest-authorized local objective planning. Current product documentation now identifies these capabilities as part of 2.2.0 and retains the provider qualification limits.

Interactive Codex resume preserves the v2.1.0 cwd-scoped `resume --last` behavior. Headless `exec --resume-run` remains bound to an exact successful run receipt; the public Codex fixture exercises that path and rejects implicit latest-session selection. No state or protocol version changes are introduced.

Validation: interactive profile regressions and the public tmux resume check pass; public headless Codex execution and exact-session resume pass. Local shell, native/fleet, PTY, parity, installation/uninstall, and all 39 onboarding checks passed. Hosted CI must pass before merging, followed by qualification of the exact main commit and verification of source archives and checksums before publication.
