### PR TITLE
Plan tmux-optional headless execution milestones

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,8 +1,8 @@
 # Hydra Roadmap
 
 > - **Status:** canonical outstanding-work backlog
-> - **Snapshot:** 7 September 2026
-> - **Current release:** `v2.2.0` workflow data, agent adapters, and local objective planning
+> - **Snapshot:** 8 September 2026
+> - **Current release:** `v2.2.1` correctness and trust hardening
 > - **Release planning:** versions are assigned from compatibility impact when backlog work is ready
 > - **Related:** [README](../README.md) · [CHANGELOG](../CHANGELOG.md) ·
 >   [Release policy](VERSIONING.md) · [Contracts](CONTRACTS.md) ·
@@ -43,8 +43,9 @@ version number is chosen at release time from compatibility impact.
   unattended schedules and reboot recovery need an explicit execution owner.
 - State remains inspectable with ordinary filesystem and shell tools.
 - Git and tmux remain authorities for repository and terminal state. Preserve the
-  current head contract while adding task identity above heads and instances;
-  introduce another execution backend only for a demonstrated requirement.
+  current interactive head contract while separating terminal attachment from
+  headless execution. The tmux-optional milestones below extend the existing task
+  owner; they do not introduce another scheduler or remove interactive sessions.
 - Native frontends delegate mutations to the shell CLI instead of duplicating policy.
 - Public changes follow [VERSIONING.md](VERSIONING.md), including deprecation,
   migration, and rollback requirements. Replace internal interfaces in place;
@@ -108,6 +109,57 @@ fixture tests and local authentication do not close another provider's remote
 requirement. Claude remains explicitly deferred rather than blocking the other
 implemented profiles.
 
+#### T. Optional tmux for headless and remote execution
+
+Decision: make tmux optional for headless execution, retaining it for interactive
+heads. This is planned behavior, not a change to current dependency requirements.
+See [the updated analysis](research/tmux-optional-execution.md) for the current
+implementation, affected contracts, and design tradeoffs. T1 and T2 precede the
+headless distributed acceptance in priority 5; resource admission can proceed in
+parallel. These are delivery milestones, not assigned release versions.
+
+- [ ] **T1 — Terminal-independent workspace and execution identity.** Separate
+      workspace, trust, identity, and provenance creation from terminal launch in
+      the shell mutation path. Support a headless execution with no terminal;
+      preserve existing interactive spawn/attach behavior. Define the durable
+      representation and compatibility treatment before changing session fields.
+      Update lifecycle, cleanup, result readers, and CLI/TUI observations together;
+      an absent terminal must not mean a dead worker. Keep cancellation distinct
+      from workspace deletion and preserve dirty work.
+      Acceptance: a local command and headless adapter execute and produce verified
+      artifacts without invoking tmux; status and teardown work for both execution
+      modes. Existing state and interactive workflows remain readable and usable,
+      with migration/rollback checks where the durable contract changes.
+- [ ] **T2 — Remote execution and planning without tmux.** Route remote exec and
+      headless workflow steps through T1 and the existing detached task owner.
+      Make admission, bootstrap, doctor, installation, and capability negotiation
+      require tmux only for terminal operations. Extend plan schema/validation and
+      lowering explicitly; preserve published spawn semantics and existing compiled
+      artifact bindings. Unsupported remote or terminal capabilities fail before
+      launch, rather than silently changing the requested execution mode.
+      Acceptance: on hosts without tmux installed, submit a command and an available
+      authenticated headless adapter, disconnect, reconnect, collect exact outputs,
+      and consume them in a dependent step. Run the corresponding local compiled
+      plan through public interfaces. Exercise duplicate submission, lost start
+      response, owner death, cancellation, and bounded logs; uncertain work is never
+      replayed and retained reservations are not released by terminal absence.
+- [ ] **T3 — Distributed qualification and operator access.** Use T2 for priority
+      5's two-host fan-out, validation, join, composition, and final check. Expose
+      run/step/attempt logs and owner state through CLI/TUI without requiring attach.
+      Interactive terminal access remains an explicit capability; viewing logs is
+      not attachment to a headless process's stdin.
+      Acceptance: the complete distributed scenario succeeds with tmux absent on
+      execution hosts. Coordinator restart and lost acknowledgments preserve task
+      identity; stale results cannot advance dependents. Re-run interactive spawn,
+      attach, messaging, transcript, and teardown regressions with tmux installed.
+
+Host service management is a conditional extension of these milestones. Add systemd
+or launchd integration only for an explicit logout/reboot recovery requirement,
+reusing the same owner and reconciliation records. Qualify those failure boundaries
+separately; service restart must not replay uncertain work. No permanent daemon,
+replacement terminal multiplexer, automatic failover, or isolation guarantee is
+required to complete T1–T3.
+
 #### 4. Resource admission
 
 Start with explicit hosts and FIFO admission. Build this boundary alongside the
@@ -132,7 +184,8 @@ Extend the existing finite workflow DAG across explicitly selected hosts. Produc
 create artifacts, validators examine those exact artifacts, and a deterministic
 policy step combines their evidence. Composition workers integrate code, reconcile
 designs, or synthesize reports; their new deliverables must be validated again.
-These are workflow roles, not separate scheduler services.
+These are workflow roles, not separate scheduler services. The headless execution
+path uses T1–T2; its tmux-free two-host qualification closes T3 as well.
 
 - [ ] Add individual remote steps through the existing fleet task interface, with
       one durable coordinator per run. Persist the resolved graph, source/input

--- a/docs/research/tmux-optional-execution.md
+++ b/docs/research/tmux-optional-execution.md
@@ -1,0 +1,112 @@
+# Optional tmux for headless execution
+
+Analysis updated 8 September 2026 against main commit `0319959` (v2.2.1).
+Status: recommendation and implementation milestones; no runtime change or new
+remote qualification is claimed by this document.
+
+## Recommendation
+
+Make tmux optional for headless local and remote work, and retain it for interactive
+heads. Extend the existing detached task owner instead of replacing supervision or
+adding another scheduler. The benefit is removing an unnecessary terminal lifecycle
+from command/agent execution and making worker ownership easier to explain.
+Removing tmux entirely would also require replacing useful attach, input, layout,
+and transcript behavior; there is no demonstrated need for that larger change.
+
+## What changed since the initial investigation
+
+Main now includes local objective planning and the v2.2.1 correctness/trust fixes.
+Fleet sources were reorganized into task, transport, support, agent, and plan
+modules. The earlier flat source paths are obsolete. Local planning already lowers
+into the existing workflow engine; it must be included in this migration rather
+than treated as future work. Distributed planning/execution remains outstanding.
+See [plan compilation](../PLAN_COMPILATION.md) and
+[the roadmap](../ROADMAP.md#candidate-features).
+
+The underlying tmux dependency remains:
+
+| Responsibility | Current source and behavior | Required change |
+| --- | --- | --- |
+| Disconnected task ownership | [task_launch.c](../../src/fleet/task/task_launch.c) syncs launch intent, retains an owner lock, double-forks, calls `setsid`, and redirects stdio | Reuse; do not substitute terminal liveness for ownership |
+| Command supervision | [process.c](../../src/fleet/support/process.c) manages process groups, deadlines, bounded capture, and cancellation | Reuse and qualify the changed execution path |
+| Remote exec workspace | [task_execute.c](../../src/fleet/task/task_execute.c) calls `spawn task --no-agent` before `exec` | Create workspace/identity without a terminal |
+| Receiver requirements | [task_accept.c](../../src/fleet/task/task_accept.c) and [bootstrap.c](../../src/fleet/transport/bootstrap.c) require tmux | Check capabilities needed by the actual operation |
+| Local plan contract | [plan_schema.c](../../src/fleet/plan/plan_schema.c) supports local spawn/exec; [plan_graph.c](../../src/fleet/plan/plan_graph.c) requires exec to depend on its head's spawn | Explicit compatible extension and lowering for terminal-free workspaces |
+| Durable head lifecycle | [state_v2.sh](../../lib/state_v2.sh), [lifecycle.sh](../../lib/lifecycle.sh), and [kill.sh](../../lib/kill.sh) assume terminal session fields or use tmux observation/teardown | Define terminal-independent state and update all affected readers/writers |
+
+The existing remote owner already survives an ordinary SSH disconnect independently
+of tmux. That does not guarantee survival of every host logout policy or a reboot.
+Headless provider invocation currently still uses a head whose workspace was
+created through terminal-backed spawn. Deleting dependency checks alone is therefore
+insufficient. Cleanup and status must also stop treating missing terminals as dead
+executions; see [maintenance.sh](../../lib/maintenance.sh).
+
+Existing [remote acceptance](../REMOTE_TASK_ACCEPTANCE.md) records lost responses,
+cancellation, and refusal to replay after owner loss. Those records qualify their
+original paths, not execution on a machine without tmux.
+
+## Intended boundaries
+
+1. The DAG coordinator owns dependencies, assignment, result admission, and recovery
+   decisions. Persist identity and exact inputs before dispatch.
+2. The receiving-host task owner owns one execution attempt, command supervision,
+   cancellation, logs, and the durable outcome. Keep the existing shell mutation
+   authority and native execution implementation.
+3. A workspace supplies source, inputs, trust, and provenance without requiring a
+   terminal. Preserve repository-based execution initially.
+4. A terminal is an optional interactive resource. Existing interactive spawn,
+   attach, messaging, layouts, and transcript capture continue to use tmux.
+
+A headless attempt should expose logs and structured observations through its
+run/step/attempt identity. Log viewing cannot promise interactive stdin attachment.
+Provider conversation IDs, process identity, terminal identity, and task identity
+remain distinct. Do not build a PTY server merely to recreate tmux for headless work.
+
+Cancellation and workspace destruction are separate operations. A stopped process
+may leave useful or dirty outputs. Conversely, a surviving terminal or provider
+conversation is not proof that an execution is active or successful.
+
+## Compatibility and recovery
+
+[Public contracts](../CONTRACTS.md) currently require tmux for core shell operation,
+and durable state v2 requires session fields. Before T1 implementation, decide the
+explicit representation of terminal-free execution and its schema/version impact.
+Do not put fake session names in existing records or silently reinterpret an old
+compiled plan's spawn operation. Update validation, lifecycle, result collection,
+provenance, maintenance, and frontends with the writer change. Old interactive heads
+retain their behavior. Changed durable formats need the migration/rollback required
+by [release policy](../VERSIONING.md); incompatible removals require its deprecation
+window and major-release treatment. Optional new capability need not remove a
+published interface.
+
+Keep one execution authority. Process-group signalling is not OS isolation and
+cannot certify arbitrary descendants that escape the group. Owner death, uncertain
+cancellation, or a lost acknowledgment must remain unresolved until reconciled;
+none authorizes redispatch on another host. Admission must retain unresolved claims.
+Tmux removal does not add safe external-effect retries, reboot recovery, automatic
+coordinator failover, or provider authentication.
+
+For an explicit requirement to run through logout/reboot, evaluate host-managed
+supervision around the same task owner: systemd on Linux or launchd on macOS. Define
+owner identity across boots/PID reuse and foreground service operation before adding
+restart policy. Reconcile durable state before any launch; restarting the service
+must not blindly restart the task. Stronger process containment and platform-specific
+logout/reboot trials are separate acceptance work, not prerequisites for basic
+terminal-free execution.
+
+## Delivery and acceptance
+
+[Roadmap milestones T1–T3](../ROADMAP.md#t-optional-tmux-for-headless-and-remote-execution)
+sequence workspace/state separation, remote and compiled-plan execution, then
+cross-host DAG qualification. Resource admission may proceed independently, but the
+first headless distributed DAG should use the new path rather than further couple
+planning to terminal sessions.
+
+The decisive first proof is a command and headless adapter run on a host without
+tmux installed: submit, disconnect, reconnect, collect exact artifacts, and consume
+an output in a dependent step. Keep provider sign-in requirements visible; fixture
+success does not qualify a live provider. Follow with duplicate/lost-response,
+owner-loss, cancellation, log-limit, and interactive regression checks. Two-host
+fan-out and verified composition complete the distributed milestone. Performance
+benefits remain unmeasured; dependency removal and clearer ownership are the current
+reasons for the change.


### PR DESCRIPTION
Hydra's remote task owner already detaches independently of tmux, but workspace creation and local compiled plans still require terminal-backed heads. Refresh the investigation against v2.2.1 and add three milestones for terminal-independent identity/workspaces, tmux-free remote and planned execution, and two-host DAG qualification while preserving interactive tmux support.

The roadmap makes compatibility, cancellation uncertainty, artifact bindings, and the dependency on distributed DAG work explicit. This changes documentation only; tmux remains required by the current runtime.

Validation: `make lint`, `git diff --check`, and local Markdown target/anchor checks passed. Existing unfinished planner changes and local artifacts are excluded.
