### PR TITLE
Make statistics fault assertions compatible with ShellCheck 0.11

### DIFF
--- a/tests/test_workflow_runtime.sh
+++ b/tests/test_workflow_runtime.sh
@@ -231,8 +231,8 @@ PATH="$test_root/statistics-bin:$PATH" HYDRA_TEST_REAL_MV="$statistics_real_mv" 
     HYDRA_TEST_STATS_FIELD=started-at HYDRA_TEST_STATS_MARKER="$test_root/start.fault" \
     "$HYDRA_BIN" workflow run "$test_root/start-fault.yml" > "$test_root/start-fault.out"
 assert_success $? "optional run start timestamp failure does not block execution"
-test -f "$test_root/start.fault"
-assert_success $? "run start timestamp write failure was exercised"
+if [ -f "$test_root/start.fault" ]; then statistics_marker_status=0; else statistics_marker_status=1; fi
+assert_success "$statistics_marker_status" "run start timestamp write failure was exercised"
 start_fault_run="$(sed -n '1p' "$test_root/start-fault.out")"
 start_fault_dir="$(run_dir_for "$start_fault_run")"
 assert_equal succeeded "$(cat "$start_fault_dir/state")" "run without start timing still succeeds"
@@ -256,8 +256,8 @@ PATH="$test_root/statistics-bin:$PATH" HYDRA_TEST_REAL_MV="$statistics_real_mv" 
     HYDRA_TEST_STATS_FIELD=recovery-count HYDRA_TEST_STATS_MARKER="$test_root/recovery.fault" \
     "$HYDRA_BIN" workflow resume "$backoff_run" >/dev/null
 assert_success $? "resume completes a retry with durable backoff"
-test -f "$test_root/recovery.fault"
-assert_success $? "optional recovery counter write failure was exercised"
+if [ -f "$test_root/recovery.fault" ]; then statistics_marker_status=0; else statistics_marker_status=1; fi
+assert_success "$statistics_marker_status" "optional recovery counter write failure was exercised"
 python3 "$(dirname "$HYDRA_BIN")/../tests/statistics_evidence.py" "$HYDRA_BIN" "$backoff_dir" - unverified
 assert_success $? "failed counter persistence discards the old count and remains unknown"
 assert_equal "$backoff_at" "$(cat "$backoff_dir/steps/retry/attempt-1/retry-at")" "restart preserves retry deadline"

--- a/tests/workflow_plan_statistics_cases.sh
+++ b/tests/workflow_plan_statistics_cases.sh
@@ -15,8 +15,8 @@ for timing_field in verified-at verification-plan-sha256; do
         "$HYDRA_BIN" workflow plan run "$ROOT/timing-$timing_field.json" --accept "$timing_digest" \
         > "$ROOT/timing-$timing_field.out" 2> "$ROOT/timing-$timing_field.err"
     assert_success $? "optional $timing_field persistence failure preserves verified delivery"
-    test -f "$ROOT/timing-$timing_field.fault" && test -f "$ROOT/timing-$timing_field.fault.seeded"
-    assert_success $? "injected $timing_field write failure after seeding old timing"
+    if [ -f "$ROOT/timing-$timing_field.fault" ] && [ -f "$ROOT/timing-$timing_field.fault.seeded" ]; then timing_marker_status=0; else timing_marker_status=1; fi
+    assert_success "$timing_marker_status" "injected $timing_field write failure after seeding old timing"
     timing_run="$(sed -n '1p' "$ROOT/timing-$timing_field.out")"
     timing_dir="$(find "$HYDRA_HOME/state/v2/projects" -type d -path "*/workflows/runs/$timing_run" -print)"
     assert_equal succeeded "$(cat "$timing_dir/state")" "verified plan succeeds without $timing_field"


### PR DESCRIPTION
ShellCheck 0.11 flags three new statistics fault-marker assertions for reading `$?` after a condition. Record each condition result explicitly before passing it to the existing assertion helper. Missing fault markers still fail the same assertions; production code is unchanged.

Validation: `make lint` passed with local ShellCheck 0.11 and dash; workflow runtime passed 47/47 and plan acceptance passed 78/78 with the native statistics helper and isolated tmux state. This is a focused follow-up to #80. Full Linux/macOS native acceptance already passed on the identical production code in CI run 34294261581.
